### PR TITLE
Add support for treating multiple YAML files as one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # KB-Util 
 
-Assorted utility classes used at the royal Danish Library
+Assorted utility classes used at the Royal Danish Library
 
-Java 11 required
+## Requirements
+
+* Java 11
+

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
   <parent>
     <groupId>org.sbforge</groupId>
     <artifactId>sbforge-parent</artifactId>
-    <version>21</version>
+    <version>22</version>
   </parent>
 
   <groupId>dk.kb.util</groupId>
   <artifactId>kb-util</artifactId>
-  <version>1.0.1-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
 
   <scm>
     <url>https://github.com/Det-Kongelige-Bibliotek/kb-util</url>
@@ -47,7 +47,7 @@
     <profile>
       <id>allTests</id>
       <properties>
-        <test.groups>fast,slow</test.groups>
+        <excluded.groups />
       </properties>
     </profile>
   </profiles>

--- a/src/main/java/dk/kb/util/Resolver.java
+++ b/src/main/java/dk/kb/util/Resolver.java
@@ -94,10 +94,9 @@ public class Resolver {
     /**
      * Resolves the resource using {@link #resolveStream(String)}, assuming UTF-8, and returns its content as a String.
      * @param resourceName the name of the resource, typically a file name.
-     * @param charset the charset to use when converting the bytes for the resource to a String.
-     * @return
+     * @return the content of the UTF-8 resource as a String.
      */
-    public static String resolveUTF8String(String resourceName, Charset charset) throws IOException {
+    public static String resolveUTF8String(String resourceName) throws IOException {
         return resolveString(resourceName, StandardCharsets.UTF_8);
     }
 
@@ -105,7 +104,7 @@ public class Resolver {
      * Resolves the resource using {@link #resolveStream(String)} and returns its content as a String.
      * @param resourceName the name of the resource, typically a file name.
      * @param charset the charset to use when converting the bytes for the resource to a String.
-     * @return
+     * @return the content of the resource as a String.
      */
     public static String resolveString(String resourceName, Charset charset) throws IOException {
         InputStream in = resolveStream(resourceName);

--- a/src/main/java/dk/kb/util/Resolver.java
+++ b/src/main/java/dk/kb/util/Resolver.java
@@ -17,11 +17,11 @@ package dk.kb.util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -40,8 +40,23 @@ public class Resolver {
      * @return an URL to the resource.
      * @throws FileNotFoundException if the resource could not be located.
      * @throws MalformedURLException if the resource location could not be converted to an URL.
+     * @deprecated use {@link #resolveURL(String)} instead.
      */
     public static URL resolveConfigFile(String resourceName) throws FileNotFoundException, MalformedURLException {
+        return resolveURL(resourceName);
+    }
+
+    /**
+     * Resolve the given resource to an URL. Order of priority:
+     * 1. Verbatim as file
+     * 2. On the path
+     * 3. In user home
+     * @param resourceName the name of the resource, typically a file name.
+     * @return an URL to the resource.
+     * @throws FileNotFoundException if the resource could not be located.
+     * @throws MalformedURLException if the resource location could not be converted to an URL.
+     */
+    public static URL resolveURL(String resourceName) throws FileNotFoundException, MalformedURLException {
         Path verbatimPath = Path.of(resourceName);
         if (Files.exists(verbatimPath)) {
             return verbatimPath.toUri().toURL();
@@ -70,9 +85,62 @@ public class Resolver {
      */
     public static InputStream resolveStream(String resourceName) {
         try {
-            return resolveConfigFile(resourceName).openStream();
+            return resolveURL(resourceName).openStream();
         } catch (Exception e) {
             throw new RuntimeException("Exception fetching resource '" + resourceName + "'", e);
         }
     }
+
+    /**
+     * Resolves the resource using {@link #resolveStream(String)}, assuming UTF-8, and returns its content as a String.
+     * @param resourceName the name of the resource, typically a file name.
+     * @param charset the charset to use when converting the bytes for the resource to a String.
+     * @return
+     */
+    public static String resolveUTF8String(String resourceName, Charset charset) throws IOException {
+        return resolveString(resourceName, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Resolves the resource using {@link #resolveStream(String)} and returns its content as a String.
+     * @param resourceName the name of the resource, typically a file name.
+     * @param charset the charset to use when converting the bytes for the resource to a String.
+     * @return
+     */
+    public static String resolveString(String resourceName, Charset charset) throws IOException {
+        InputStream in = resolveStream(resourceName);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        pipe(in, out);
+        return out.toString(charset);
+    }
+
+    /**
+     * Shorthand for {@link #pipe(java.io.InputStream, java.io.OutputStream, int)}.
+     * A default buffer of 4KB is used.
+     *
+     * @param in  The source stream.
+     * @param out The target stream.
+     * @throws java.io.IOException If any sort of read/write error occurs on either stream.
+     */
+    public static void pipe(InputStream in, OutputStream out) throws IOException {
+        pipe(in, out, 4096);
+    }
+
+    /**
+     * Copies the contents of an InputStream to an OutputStream, then closes both.
+     * @param in      The source stream.
+     * @param out     The destination stram.
+     * @param bufSize Number of bytes to attempt to copy at a time.
+     * @throws java.io.IOException If any sort of read/write error occurs on either stream.
+     */
+    public static void pipe(InputStream in, OutputStream out, int bufSize) throws IOException {
+        try (in; out) {
+            byte[] buf = new byte[bufSize];
+            int len;
+            while ((len = in.read(buf)) > 0) {
+                out.write(buf, 0, len);
+            }
+        }
+    }
+
 }

--- a/src/main/java/dk/kb/util/Resolver.java
+++ b/src/main/java/dk/kb/util/Resolver.java
@@ -18,6 +18,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Files;
@@ -58,5 +60,19 @@ public class Resolver {
         }
         log.debug("Resolved '{}' to '{}'", resourceName, configURL);
         return configURL;
+    }
+
+    /**
+     * Wrapper for {@link #resolveConfigFile(String)} that opens an InputStream for the given resource.
+     * Note: This method has no checked exceptions: It wraps IOExceptions as runtime exceptions.
+     * @param resourceName the name of the resource, typically a file name.
+     * @return a stream with the given resource.
+     */
+    public static InputStream resolveStream(String resourceName) {
+        try {
+            return resolveConfigFile(resourceName).openStream();
+        } catch (Exception e) {
+            throw new RuntimeException("Exception fetching resource '" + resourceName + "'", e);
+        }
     }
 }

--- a/src/main/java/dk/kb/util/YAML.java
+++ b/src/main/java/dk/kb/util/YAML.java
@@ -290,8 +290,8 @@ public class YAML extends LinkedHashMap<String, Object> {
 
     /**
      * Resolve the given YAML configurations and present a merged YAML from that.
-     * Note: This method merges the YAML configs as-is, which means that they cannot have identical keys at
-     * the root level.
+     * Note: This method merges the YAML configs as-is: Any key-collisions are handled implicitly by keeping the latest
+     * key-value pair in the stated configurations.
      * @param configNames the names of the configuration files.
      * @return the configurations merged and parsed up as a tree represented as Map and wrapped as YAML.
      * @throws IOException if a configuration could not be fetched.

--- a/src/test/java/dk/kb/util/YAMLTest.java
+++ b/src/test/java/dk/kb/util/YAMLTest.java
@@ -64,4 +64,11 @@ class YAMLTest {
         assertEquals("FooServer", yaml.getString("serviceSetup.theServer"),
                      "The merged YAML should have the expected value for alias-using 'theServer'");
     }
+
+    @Test
+    public void testMergeCollision() throws IOException {
+        YAML yaml = YAML.resolveMultiConfig("config_pair_part_1.yml", "config_pair_part_2.yml");
+        assertEquals("number_2", yaml.getString("collision"),
+                     "When merging, the latest definition should win");
+    }
 }

--- a/src/test/java/dk/kb/util/YAMLTest.java
+++ b/src/test/java/dk/kb/util/YAMLTest.java
@@ -1,6 +1,8 @@
 package dk.kb.util;
 
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
 
 import java.io.IOException;
 
@@ -45,5 +47,21 @@ class YAMLTest {
         YAML yaml = YAML.resolveConfig("test.yml", "test");
         assertEquals("[a, b, c]", yaml.getList("arrayofstrings").toString(),
                      "Arrays of strings should be supported");
+    }
+
+    @Test
+    public void testAlias() throws IOException {
+        YAML yaml = YAML.resolveMultiConfig("alias.yml");
+        assertEquals("FooServer", yaml.getString("serviceSetup.theServer"),
+                     "The alias YAML should have the expected value for alias-using 'theServer'");
+    }
+
+    @Test
+    public void testMultiConfig() throws IOException {
+        YAML yaml = YAML.resolveMultiConfig("config_pair_part_1.yml", "config_pair_part_2.yml");
+        assertEquals("bar", yaml.getString("serviceSetup.someString"),
+                     "The merged YAML should have the expected value for plain key 'somestring'");
+        assertEquals("FooServer", yaml.getString("serviceSetup.theServer"),
+                     "The merged YAML should have the expected value for alias-using 'theServer'");
     }
 }

--- a/src/test/resources/alias.yml
+++ b/src/test/resources/alias.yml
@@ -1,0 +1,10 @@
+# Alias test
+environment:
+  someint: 87
+  serverSetup:
+  serviceServer: &theServer "FooServer"
+
+serviceSetup:
+  theServer: *theServer
+  # theServer will be used from &myserver
+  someString: "bar"

--- a/src/test/resources/config_pair_part_1.yml
+++ b/src/test/resources/config_pair_part_1.yml
@@ -1,0 +1,4 @@
+environment:
+  someint: 87
+  serverSetup:
+  serviceServer: &theServer "FooServer"

--- a/src/test/resources/config_pair_part_1.yml
+++ b/src/test/resources/config_pair_part_1.yml
@@ -2,3 +2,5 @@ environment:
   someint: 87
   serverSetup:
   serviceServer: &theServer "FooServer"
+# The key collision is defined on the same level for both part 1 and part 2, but with different values
+collision: "number_1"

--- a/src/test/resources/config_pair_part_2.yml
+++ b/src/test/resources/config_pair_part_2.yml
@@ -3,3 +3,5 @@ serviceSetup:
   theServer: *theServer
   # theServer will be used from &myserver
   someString: "bar"
+# The key collision is defined on the same level for both part 1 and part 2, but with different values
+collision: "number_2"

--- a/src/test/resources/config_pair_part_2.yml
+++ b/src/test/resources/config_pair_part_2.yml
@@ -1,0 +1,5 @@
+serviceSetup:
+  # A YAML validator will complain about the missing alias definition, but it is defined in config_pair_part_1.yml
+  theServer: *theServer
+  # theServer will be used from &myserver
+  someString: "bar"


### PR DESCRIPTION
The specific use case was to use the alias mechanism to separate environment from behaviour. This is demonstrated in the `YAMLTest` unit test.