### PR TITLE
Fix backwards incompatibility from moving the YAML-class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Shadow-class `dk.kb.util.YAML` introduced to compensate for breaking backwards
+compatibility in 1.2.0.
+
 ## [1.2.0](https://github.com/kb-dk/kb-util/tree/kb-util-1.2.0)
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ review your changes.
 The content of `kb-util` is expected to be used across multiple projects and it is
 expected to be a light weight dependency: Please don't add an utility for OCRing of
 subtitles from video streams, requiring gigabytes of third party libraries.
+
+**Important:** Refactoring or other changes that breaks backwards compatibility
+should be explicitly discussed with the reviewer.
  
 ## Release procedure
 

--- a/src/main/java/dk/kb/util/YAML.java
+++ b/src/main/java/dk/kb/util/YAML.java
@@ -1,0 +1,33 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package dk.kb.util;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Direct wrapper for {@link dk.kb.util.yaml.YAML}. Exists only for backwards compatibility.
+ *
+ * @deprecated Use the implementation at dk.kb.util.yaml.YAML.
+ */
+public class YAML extends dk.kb.util.yaml.YAML {
+    public YAML(String resourceName) throws IOException {
+        super(resourceName);
+    }
+
+    public YAML(Map<String, Object> map) {
+        super(map);
+    }
+}


### PR DESCRIPTION
Version 1.2.0 moved the YAML class. This pull-request introduces a shadow-class so that backwards compatibility is maintained.