### PR TITLE
Include license info in the generated jar file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,13 @@
         <tag>HEAD</tag>
     </scm>
 
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+        </license>
+    </licenses>
+
     <repositories>
         <repository>
             <id>sbforge-nexus</id>
@@ -42,6 +49,47 @@
              to disable forbidden APIs check -->
         <api.check.phase>process-test-classes</api.check.phase>
     </properties>
+
+    <build>
+        <resources>
+            <resource>
+                <directory>target/generated-resources</directory>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>license-maven-plugin</artifactId>
+                <version>2.0.0</version>
+                <executions>
+                    <execution>
+                        <id>download-licenses</id>
+                        <goals>
+                            <goal>download-licenses</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <licensesOutputDirectory>
+                                ${project.build.directory}/generated-resources/META-INF/dependencies-licenses
+                            </licensesOutputDirectory>
+                            <excludedScopes>test</excludedScopes>
+                            <licensesConfigFile>
+                                ${project.build.directory}/generated-resources/META-INF/dependencies-licenses-config.xml
+                            </licensesConfigFile>
+                            <licensesOutputFile>
+                                ${project.build.directory}/generated-resources/META-INF/dependencies-licenses.xml
+                            </licensesOutputFile>
+                            <licensesErrorsFile>
+                                ${project.build.directory}/generated-resources/META-INF/dependencies-licenses-errors.xml
+                            </licensesErrorsFile>
+                            <includeTransitiveDependencies>true</includeTransitiveDependencies>
+                            <organizeLicensesByDependencies>true</organizeLicensesByDependencies>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
     <dependencies>
         <!-- https://mvnrepository.com/artifact/jakarta.validation/jakarta.validation-api -->


### PR DESCRIPTION
Licenses included due to discussions about opensourcing.

1. The pom.xml now list the project license.
2. The produced jar now includes the licenses and a `dependencies-licenses.xml` file