### PR TITLE
Add globbing resolver

### DIFF
--- a/src/main/java/dk/kb/util/Resolver.java
+++ b/src/main/java/dk/kb/util/Resolver.java
@@ -29,9 +29,19 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Resolves resources using best effort (verbatim given string, looking in user home, on the path etc).
@@ -94,7 +104,59 @@ public class Resolver {
         log.debug("Resolved '{}' to '{}'", resourceName, configURL);
         return configURL;
     }
-    
+
+    /**
+     * Resolve 0 or more files from a given glob. If no absolute path is given, the current path and users home is used.
+     * Examples: {@code myconfig*.yaml}, {@code setup/myconfig.yaml}, {@code /home/someapp/conf/prod-*-conf/*.yaml}.
+     * @param glob a Unix-style glob, using the syntax from {@link java.nio.file.FileSystem#getPathMatcher(String)}
+     *             with the exception of {@code **}.
+     * @return a list of Paths matching the given glob or the empty list if there were no matches.
+     */
+    public static List<Path> resolveGlob(String glob) {
+        List<Path> paths = new ArrayList<>();
+        if (glob == null || glob.isEmpty()) {
+            return paths;
+        }
+
+        List<String> prefixes = new ArrayList<>();
+        if (Paths.get(glob).isAbsolute()) {
+            prefixes.add(""); // Empty String is prefix for absolute paths
+        } else { // user home & current
+            prefixes.add(System.getProperty("user.home") + File.separator);
+            prefixes.add(FileSystems.getDefault().getPath("").toAbsolutePath().toString() + File.separator);
+        }
+
+        for (String prefix: prefixes) {
+            String absoluteGlob = prefix + glob;
+            List<PathMatcher> matchers = Arrays.stream(absoluteGlob.split(Pattern.quote(File.separator))).
+                    filter(segment -> !segment.isEmpty()).
+                    map(segment -> FileSystems.getDefault().getPathMatcher("glob:" + segment)).
+                    collect(Collectors.toList());
+            for (File root: File.listRoots()) {
+                walkMatches(root.toPath(), matchers, 0, paths::add);
+            }
+        }
+        log.debug("Resolved glob '" + glob + "' to " + paths.size() + " files");
+        return paths;
+    }
+    // Recursive descend through folders matching the segments
+    private static void walkMatches(
+            Path current, List<PathMatcher> matchers, int matchersIndex, Consumer<Path> consumer) {
+        if (!Files.isDirectory(current)) {
+            if (matchersIndex == matchers.size()) {
+                consumer.accept(current);
+            }
+            return;
+        }
+        try {
+            Files.list(current).
+                    filter(path -> matchers.get(matchersIndex).matches(path.getFileName())).
+                    forEach(path -> walkMatches(path, matchers, matchersIndex+1, consumer));
+        } catch (IOException e) {
+            throw new RuntimeException("IOException while walking " + current, e);
+        }
+    }
+
     /**
      * Wrapper for {@link #resolveConfigFile(String)} that opens an InputStream for the given resource.
      * Note: This method has no checked exceptions: It wraps IOExceptions as runtime exceptions.

--- a/src/main/java/dk/kb/util/Resolver.java
+++ b/src/main/java/dk/kb/util/Resolver.java
@@ -140,6 +140,7 @@ public class Resolver {
             }
         }
         log.debug("Resolved glob '" + glob + "' to " + paths.size() + " files");
+        Collections.sort(paths);
         return paths;
     }
     // Recursive descend through folders matching the segments

--- a/src/main/java/dk/kb/util/Resolver.java
+++ b/src/main/java/dk/kb/util/Resolver.java
@@ -145,7 +145,7 @@ public class Resolver {
             }
         }
         Collections.sort(paths);
-        log.debug("Resolved glob '" + glob + "' to " + paths.size() + " files");
+        log.debug("Resolved glob '" + glob + "' to " + paths);
         return paths;
     }
     // Recursive descend through folders matching the segments

--- a/src/test/java/dk/kb/util/ResolverTest.java
+++ b/src/test/java/dk/kb/util/ResolverTest.java
@@ -1,10 +1,16 @@
 package dk.kb.util;
 
+import org.apache.commons.io.filefilter.WildcardFileFilter;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
 import java.io.IOException;
+import java.net.URL;
+import java.nio.file.DirectoryStream;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.PathMatcher;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -28,6 +34,30 @@ class ResolverTest {
     @Test
     void readFileFromClasspath() throws IOException {
         assertThat(Resolver.readFileFromClasspath("resolver/testfile.txt"),is("contents\n"));
+    }
+
+    @Test
+    void resolveGlob() throws IOException {
+        URL url1 = Resolver.resolveURL("yaml/overwrite-1.yaml");
+        assertThat("The test files should be available", notNullValue().matches(url1));
+
+        String parent2 = new File(url1.getPath()).getParentFile().getParent(); // 2 steps up so we can check path *
+        assertThat("Sanity check path should work", Files.exists(Path.of(parent2, "yaml/overwrite-1.yaml")));
+
+        assertThat("The right number of files should be resolved for file wildcard",
+                   Resolver.resolveGlob(parent2 + "/yaml/overwrite*.yaml").size() == 2);
+
+        assertThat("The right number of files should be resolved for single character file wildcard",
+                   Resolver.resolveGlob(parent2 + "/yaml/overwrite-?.yaml").size() == 2);
+
+        assertThat("The right number of files should be resolved for path wildcard",
+                   Resolver.resolveGlob(parent2 + "/*/overwrite*.yaml").size() == 2);
+
+        assertThat("The right number of files should be resolved for bracket wildcard",
+                   Resolver.resolveGlob(parent2 + "/yaml/overwrite-[2-3].yaml").size() == 1);
+
+        assertThat("The right number of files should be resolved combining globs",
+                   Resolver.resolveGlob(parent2 + "/ya[klm]l/over*-[1-2].yam?").size() == 2);
     }
 
 }

--- a/src/test/java/dk/kb/util/ResolverTest.java
+++ b/src/test/java/dk/kb/util/ResolverTest.java
@@ -1,16 +1,12 @@
 package dk.kb.util;
 
-import org.apache.commons.io.filefilter.WildcardFileFilter;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.nio.file.DirectoryStream;
-import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.PathMatcher;
 
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/test/resources/yaml/overwrite-1.yaml
+++ b/src/test/resources/yaml/overwrite-1.yaml
@@ -1,0 +1,10 @@
+upperA:
+  subElement: foo
+  subYAML:
+    sub2Element: bar
+  subList:
+    - one
+    - two
+upperB:
+  subBElement: 87
+

--- a/src/test/resources/yaml/overwrite-2.yaml
+++ b/src/test/resources/yaml/overwrite-2.yaml
@@ -1,0 +1,11 @@
+upperA:
+  subElement: baz
+  subYAML:
+    sub3Element: hello
+  subList:
+    - three
+    - four
+  extraSub: world
+upperC:
+  subCElement: 12
+


### PR DESCRIPTION
In preparation of better multi-file support for configurations, I have added globbing support to file resolving.

I have spend a lot of time looking for a library that provides the needed feature directly, but no such luck. The closest was https://github.com/EsotericSoftware/wildcard but is does not support the full set of features (brackets are not handled) and is not on Maven central.