### PR TITLE
Add support for dots in globs (foo/bar/../bar/./boom.txt)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-## [1.4.0](https://github.com/kb-dk/kb-util/tree/kb-util-1.3.0)
+- Bugfix/improvement: Globbing now supports . and .. (foo/bar/../bar/./boom.txt)
 
+## [1.4.0](https://github.com/kb-dk/kb-util/tree/kb-util-1.3.0)
 
 ### Added
 - `YAML.parse` methods that takes a Path or File as input, rather than a classpath Name or InputStream. Just for more flexibility in how to read your YAML file.

--- a/src/main/java/dk/kb/util/Resolver.java
+++ b/src/main/java/dk/kb/util/Resolver.java
@@ -142,8 +142,12 @@ public class Resolver {
             // Overall principle is recursive descend, but only visiting the folders that are viable candidates.
             // This is done by splitting the glob in segments, one segment per folder, then walking down the hierarchy
             // while ensuring that each step in the hierarchy matches the right segment of the glob.
+            List<String> segments = extractSegments(prefix + glob);
+            if (segments.isEmpty()) { // Not a viable glob
+                continue;
+            }
             List<PathMatcher> matchers =
-                    extractSegments(prefix + glob).stream().
+                    segments.stream().
                     map(segment -> FileSystems.getDefault().getPathMatcher("glob:" + segment)).
                     collect(Collectors.toList());
             // This simply resolves to {@code /} on unix systems, but there can be multiple roots on Windows

--- a/src/test/java/dk/kb/util/ResolverTest.java
+++ b/src/test/java/dk/kb/util/ResolverTest.java
@@ -57,6 +57,31 @@ class ResolverTest {
     }
 
     @Test
+    void resolveDottedGlob() throws IOException {
+        URL url1 = Resolver.resolveURL("yaml/subfolder/somefile.yaml");
+        assertThat("The test file should be available", notNullValue().matches(url1));
+
+        Path known = Path.of(url1.getPath()); // /$HOME/$USER/UNKNOWN/kb-util/target/test-classes/yaml/subfolder/somefile.yaml
+        String parent = known.getParent().getParent().getParent().getFileName().toString(); // test-classes
+
+        assertThat("The file '" + known + "' should be resolved with /./ in the path",
+                   is(Resolver.resolveGlob("yaml/subfolder/./somefile.yaml").size()).matches(1));
+
+        assertThat("The file '" + known + "' should be resolved with /../ in the path",
+                   is(Resolver.resolveGlob("yaml/subfolder/../subfolder/somefile.yaml").size()).matches(1));
+
+        assertThat("The file '" + known + "' should be resolved with ../ at the start of the path",
+                   is(Resolver.resolveGlob("../" + parent + "/yaml/subfolder/somefile.yaml").size()).matches(1));
+
+        assertThat("The file '" + known + "' should be resolved with /../../ in the path",
+                   is(Resolver.resolveGlob("yaml/subfolder/../../yaml/subfolder/somefile.yaml").size()).matches(1));
+
+        assertThat("The file '" + known + "' should be resolved with both /./ and /../ in the path",
+                   is(Resolver.resolveGlob("yaml/subfolder/./../subfolder/somefile.yaml").size()).matches(1));
+
+    }
+
+    @Test
     void resolveGlobRelative() {
         assertThat("Globbing relative to the class path should work",
                    Resolver.resolveGlob("yaml/overwrite*.yaml").size() == 2);

--- a/src/test/java/dk/kb/util/ResolverTest.java
+++ b/src/test/java/dk/kb/util/ResolverTest.java
@@ -78,8 +78,21 @@ class ResolverTest {
 
         assertThat("The file '" + known + "' should be resolved with both /./ and /../ in the path",
                    is(Resolver.resolveGlob("yaml/subfolder/./../subfolder/somefile.yaml").size()).matches(1));
+    }
+
+    @Test
+    void extractSegments() {
+        assertThat("Glob segments that dots higher than root at the start should not be seen as viable",
+                   is(Resolver.extractSegments("/../foo/bar.txt").size()).matches(0));
+
+        assertThat("Sanity check of dotting up to the edge should pass",
+                   is(Resolver.extractSegments("/foo/../foo/bar.txt").size()).matches(2));  // ["foo", "bar.txt"]
+
+        assertThat("Glob segments that dots higher than root at some point not be seen as viable",
+                   is(Resolver.extractSegments("/foo/../../boom/bar.txt").size()).matches(0));
 
     }
+
 
     @Test
     void resolveGlobRelative() {

--- a/src/test/resources/yaml/subfolder/somefile.yaml
+++ b/src/test/resources/yaml/subfolder/somefile.yaml
@@ -1,0 +1,10 @@
+upperA:
+  subElement: foo
+  subYAML:
+    sub2Element: bar
+  subList:
+    - one
+    - two
+upperB:
+  subBElement: 87
+


### PR DESCRIPTION
It is fairly common to make relative paths to config files. This introduced a regression with the switch to globbing as default, as globbing did not support it. Hereby remedied.