### PR TITLE
Add FileNotFoundExceptions to the different YAML resolvers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 
+- Better exceptions when creating a YAML from non-existing resources
 
 ## [1.4.1](https://github.com/kb-dk/kb-util/tree/kb-util-1.4.1)
 ### Bugfix

--- a/src/main/java/dk/kb/util/yaml/YAML.java
+++ b/src/main/java/dk/kb/util/yaml/YAML.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.io.SequenceInputStream;
+import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.util.*;
@@ -651,11 +652,11 @@ public class YAML extends LinkedHashMap<String, Object> {
      *
      * @param yamlPath path to YAML File.
      * @return a YAML based on the given stream.
+     * @throws IOException if a configuration could not be fetched.
+     * @throws FileNotFoundException if the given yamlFile could not be located.
      */
     public static YAML parse(Path yamlPath) throws IOException {
-        try (InputStream in = IOUtils.buffer(new FileInputStream(yamlPath.toFile()))) {
-            return parse(in);
-        }
+        return parse(yamlPath.toFile());
     }
     
     /**
@@ -663,8 +664,13 @@ public class YAML extends LinkedHashMap<String, Object> {
      *
      * @param yamlFile path to YAML File.
      * @return a YAML based on the given stream.
+     * @throws IOException if a configuration could not be fetched.
+     * @throws FileNotFoundException if the given yamlFile could not be located.
      */
     public static YAML parse(File yamlFile) throws IOException {
+        if (!yamlFile.exists()) {
+            throw new FileNotFoundException("The file '" + yamlFile + "' could not be found");
+        }
         try (InputStream in = IOUtils.buffer(new FileInputStream(yamlFile))) {
             return parse(in);
         }
@@ -678,22 +684,26 @@ public class YAML extends LinkedHashMap<String, Object> {
      * Note 2: The resolver supports globbing so {@code /home/someone/myapp-conf/*.yaml} expands to all YAML-files
      * in the {@code myapp} folder. When globbing is used, the matching files are returned in alphanumerical order.
      *
-     * @param configNames the names, paths or globs of the configuration files.
+     * @param configResources the names, paths or globs of the configuration files.
      * @return the configurations merged and parsed up as a tree represented as Map and wrapped as YAML.
      * @throws IOException if a configuration could not be fetched.
+     * @throws FileNotFoundException if none of the given configResources could be resolved.
      */
-    public static YAML resolveMultiConfig(String... configNames) throws IOException {
+    public static YAML resolveMultiConfig(String... configResources) throws IOException {
         List<InputStream> configs = null;
         try {
-            configs = Arrays.stream(configNames).
+            configs = Arrays.stream(configResources).
                     map(Resolver::resolveGlob).flatMap(Collection::stream).
                     map(YAML::openStream).
                     collect(Collectors.toList());
+            if (configs.isEmpty()) {
+                throw new FileNotFoundException("Unable to resolve any files for " + Arrays.toString(configResources));
+            }
             InputStream yamlStream = null;
             for (InputStream config : configs) {
                 yamlStream = yamlStream == null ? config : new SequenceInputStream(yamlStream, config);
             }
-            log.debug("Fetched merged YAML config '{}'", Arrays.toString(configNames));
+            log.debug("Fetched merged YAML config '{}'", Arrays.toString(configResources));
             return parse(yamlStream);
         } finally {
             if (configs != null) {

--- a/src/test/java/dk/kb/util/yaml/YAMLTest.java
+++ b/src/test/java/dk/kb/util/yaml/YAMLTest.java
@@ -3,6 +3,8 @@ package dk.kb.util.yaml;
 import org.junit.jupiter.api.Test;
 
 import javax.validation.constraints.NotNull;
+import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
 
@@ -92,6 +94,33 @@ class YAMLTest {
                      "The merged YAML should have the expected value for plain key 'somestring'");
         assertEquals("FooServer", yaml.getString("serviceSetup.theServer"),
                      "The merged YAML should have the expected value for alias-using 'theServer'");
+    }
+
+    @Test
+    public void testFailingMultiConfig() throws IOException {
+        try {
+            YAML.resolveMultiConfig("Not_there.yml", "Not_there_2.yml");
+            fail("Resolving non-existing multi-config should not work");
+        } catch (FileNotFoundException e) {
+            // Expected
+        }
+    }
+
+    @Test
+    public void testFailingParse() throws IOException {
+        try {
+            YAML.parse(new File("Non-existing"));
+            fail("Parsing missing file should not work");
+        } catch (FileNotFoundException e) {
+            // Expected
+        }
+
+        try {
+            YAML.parse(new File("Non-existing").toPath());
+            fail("Parsing missing path should not work");
+        } catch (FileNotFoundException e) {
+            // Expected
+        }
     }
 
     @Test

--- a/src/test/java/dk/kb/util/yaml/YAMLTest.java
+++ b/src/test/java/dk/kb/util/yaml/YAMLTest.java
@@ -1,13 +1,21 @@
 package dk.kb.util.yaml;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import javax.validation.constraints.NotNull;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.List;
+import java.util.Set;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 class YAMLTest {
@@ -98,30 +106,50 @@ class YAMLTest {
 
     @Test
     public void testFailingMultiConfig() throws IOException {
-        try {
-            YAML.resolveMultiConfig("Not_there.yml", "Not_there_2.yml");
-            fail("Resolving non-existing multi-config should not work");
-        } catch (FileNotFoundException e) {
-            // Expected
-        }
+        Assertions.assertThrows(FileNotFoundException.class,
+                                () -> YAML.resolveMultiConfig("Not_there.yml", "Not_there_2.yml"),
+                                "Attempting to resolve non-existing multi-config should throw an Exception");
     }
 
     @Test
     public void testFailingParse() throws IOException {
-        try {
-            YAML.parse(new File("Non-existing"));
-            fail("Parsing missing file should not work");
-        } catch (FileNotFoundException e) {
-            // Expected
-        }
+        File nonExisting = new File("Non-existing");
+        Assertions.assertThrows(FileNotFoundException.class,
+                                () -> YAML.parse(nonExisting),
+                                "Attempting to resolve non-existing config File should throw an Exception");
 
-        try {
-            YAML.parse(new File("Non-existing").toPath());
-            fail("Parsing missing path should not work");
-        } catch (FileNotFoundException e) {
-            // Expected
-        }
+        Assertions.assertThrows(FileNotFoundException.class,
+                                () -> YAML.parse(nonExisting.toPath()),
+                                "Attempting to resolve non-existing config Path should throw an Exception");
     }
+
+    @Test
+    void nonReadableException() throws IOException {
+        Set<PosixFilePermission> ownerWritable = PosixFilePermissions.fromString("-w-------"); // Only writable
+        FileAttribute<?> permissions = PosixFilePermissions.asFileAttribute(ownerWritable);
+        Path nonRead = Files.createTempFile("kbutil_", "tmp", permissions);
+        Files.writeString(nonRead, "Hello World");
+
+        // Check that the temp file was created correctly
+        assertThat("Test file '" + nonRead + "' exists", Files.exists(nonRead));
+        Assertions.assertThrows(AccessDeniedException.class, () -> Files.readString(nonRead),
+                                "Reading test file '" + nonRead + "' should throw an Exception");
+        
+
+
+        // Test that YAML throws appropriate exceptions when the resource cannot be read
+        Assertions.assertThrows(AccessDeniedException.class, () -> YAML.parse(nonRead),
+                                "Parsing  test file '" + nonRead + "' directly should throw an Exception");
+
+        Assertions.assertThrows(AccessDeniedException.class, () -> new YAML(nonRead.toString()),
+                                "Parsing  test file '" + nonRead + "' using constructor should throw an Exception");
+
+        Assertions.assertThrows(AccessDeniedException.class, () -> YAML.resolveConfig(nonRead.toString()),
+                                "Parsing  test file '" + nonRead + "' using resolve should throw an Exception");
+
+        Files.delete(nonRead);
+    }
+
 
     @Test
     public void testMultiGlob() throws IOException {
@@ -171,12 +199,9 @@ class YAMLTest {
     @Test
     public void testFailingListEntry() throws IOException {
         YAML yaml = YAML.resolveConfig("test.yml", "test");
-        try {
-            yaml.getString("arrayofstrings[3]");
-            fail("Requesting an index in a collection greater than or equal to list length should fail");
-        } catch (Exception e) {
-            // Expected
-        }
+        Assertions.assertThrows(Exception.class,
+                                () -> yaml.getString("arrayofstrings[3]"),
+                                "Requesting an index in a collection greater than or equal to list length should fail");
     }
 
     @Test


### PR DESCRIPTION
The current behaviour when trying to create a YAML from non-existing resources is to fail with `java.io.IOException: Stream closed` which could be a lot of things. This pull request makes the relevant methods throw proper `FileNotFoundException`s so that the caller knows what went wrong.