### PR TITLE
Allow for xml unmarshalling of non root elements + test

### DIFF
--- a/src/main/java/dk/kb/util/xml/XML.java
+++ b/src/main/java/dk/kb/util/xml/XML.java
@@ -9,6 +9,7 @@ import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 import javax.xml.bind.Unmarshaller;
+import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.OutputKeys;
@@ -17,6 +18,7 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -86,18 +88,20 @@ public class XML {
     public static <T> T unmarshall(String xml, Class<T> type) {
         try {
             JAXBContext jc = JAXBContext.newInstance(type);
-            
             Unmarshaller unmarshaller = jc.createUnmarshaller();
-            
             try (ByteArrayInputStream in = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))) {
-                return (T) unmarshaller.unmarshal(in);
+                if (type.isAnnotationPresent(XmlRootElement.class)) {
+                    return (T) unmarshaller.unmarshal(in);
+                } else {
+                    return unmarshaller.unmarshal(new StreamSource(in), type).getValue();
+                }
             }
         } catch (JAXBException | IOException e) {
             throw new RuntimeException(e);
         }
     }
     
-  
+    
     
     /**
      * Parses an XML document from a String to a DOM.

--- a/src/test/java/dk/kb/util/xml/XMLTest.java
+++ b/src/test/java/dk/kb/util/xml/XMLTest.java
@@ -11,14 +11,10 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 class XMLTest {
     
@@ -48,6 +44,22 @@ class XMLTest {
         MarshallTestObject object = new MarshallTestObject("foo", new Weird("bar"));
         String intermediate = XML.marshall(object);
         MarshallTestObject result = XML.unmarshall(intermediate, MarshallTestObject.class);
+        assertThat(result, is(object));
+    }
+    
+    @Test
+    void unmarshallNonRootElement()
+            throws JAXBException, IOException, SAXException, ParserConfigurationException, TransformerException {
+        MarshallTestObject marshallTestObject = new MarshallTestObject("foo", new Weird("bar"));
+        Weird object = marshallTestObject.value;
+        
+        //Create the xml for the non-root element
+        String intermediate = XML.domToString(XpathUtils
+                                                      .createXPathSelector()
+                                                      .selectNode(XML.fromXML(XML.marshall(marshallTestObject), true),
+                                                                  "/marshallTestObject/value"));
+        
+        Weird result = XML.unmarshall(intermediate, Weird.class);
         assertThat(result, is(object));
     }
     

--- a/src/test/java/dk/kb/util/xml/XMLTest.java
+++ b/src/test/java/dk/kb/util/xml/XMLTest.java
@@ -54,10 +54,13 @@ class XMLTest {
         Weird object = marshallTestObject.value;
         
         //Create the xml for the non-root element
+        //Very complex way of creating the xml blob "<value><string>bar</string></value>"
         String intermediate = XML.domToString(XpathUtils
                                                       .createXPathSelector()
                                                       .selectNode(XML.fromXML(XML.marshall(marshallTestObject), true),
                                                                   "/marshallTestObject/value"));
+        
+        assertThat(intermediate.replaceAll("\\s", ""), is("<value><string>bar</string></value>"));
         
         Weird result = XML.unmarshall(intermediate, Weird.class);
         assertThat(result, is(object));
@@ -73,7 +76,7 @@ class XMLTest {
         }
         
         public MarshallTestObject(String key, Weird value) {
-            this.key = key;
+            this.key   = key;
             this.value = value;
         }
         
@@ -102,8 +105,7 @@ class XMLTest {
                 return false;
             }
             MarshallTestObject that = (MarshallTestObject) o;
-            return Objects.equals(key, that.key) &&
-                   Objects.equals(value, that.value);
+            return Objects.equals(key, that.key) && Objects.equals(value, that.value);
         }
         
         @Override
@@ -164,5 +166,5 @@ class XMLTest {
         }
     }
     
-   
+    
 }


### PR DESCRIPTION
The conflicts are due to one of the commits having landed on master beforehand. It was then reverted, but now this branch contains the reverted commit. What a mess. Whatever, there is really no conflict, just replace the master files with the files from this branch (XML.java, XMLTest.java) and everything is fine.

About what is happening here:

Sometimes you need to unmarshal a XML blob that is not an XML Root Element. Example
```java
 @XmlRootElement
 public static class MarshallTestObject {
        String key;
        Weird value;
}

public static class Weird {
        String string;
}
```

With the previous implementation, you could do `XML.unmarshal(xmlBlob, MarshallTestObject.class)` but you cannot do `XML.unmarshal(xmlBlob2, Weird.class)`
The latter would result in an error about not finding an `@XmlRootElement` annotation on class `Weird`.

I fixed it with basically this bit of code
```java
if (type.isAnnotationPresent(XmlRootElement.class)) {
    return (T) unmarshaller.unmarshal(in);
} else {
    return unmarshaller.unmarshal(new StreamSource(in), type).getValue();
}
```
Why this is even nessesary is one of the many wonders of JAXB. 