### PR TITLE
YAML resolving with overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Better exceptions when creating a YAML from non-existing resources
+- Choice between loading multiple YAML-files as a single reference-supporting stream or as multiple overwriting streams 
 
 ## [1.4.2](https://github.com/kb-dk/kb-util/tree/kb-util-1.4.2)
 ### Testing

--- a/src/main/java/dk/kb/util/yaml/YAML.java
+++ b/src/main/java/dk/kb/util/yaml/YAML.java
@@ -692,7 +692,7 @@ public class YAML extends LinkedHashMap<String, Object> {
      * <p>
      * Note: This method merges the YAML config as-is: Any key-collisions are handled implicitly by keeping the latest
      * key-value pair. Sub-entries are not merged on key collisions, meaning that key-collisions at the root level
-     * overrides replaces the full tree under the key. References are supported with this method.
+     * replaces the full tree under the key. References are supported with this method.
      * @param yamlStream YAML.
      * @return a YAML based on the given stream.
      */
@@ -810,7 +810,9 @@ public class YAML extends LinkedHashMap<String, Object> {
     /**
      * Resolve the given YAML configurations, merging key-value pairs from subsequent configs into the first one.
      * This is typically used to support easy overwriting of specific parts of a major configuration file.
-     * This is shorthand for {@code resolveLayeredConfig(MERGE_ACTION.union, MERGE_ACTION.union, configResources}.
+     * This is shorthand for {@code resolveLayeredConfig(MERGE_ACTION.union, MERGE_ACTION.kee_extra, configResources}:
+     * The values for duplicate keys in YAMLs are merged, lists and atomic values are overwritten with the values
+     * from extra.
      * <p>
      * Note: As opposed to {@link #resolveMultiConfig(String...)} this approach does not allow for references
      * across configResources.
@@ -827,7 +829,7 @@ public class YAML extends LinkedHashMap<String, Object> {
      * @see #resolveMultiConfig for alternative.
      */
     public static YAML resolveLayeredConfigs(String... configResources) throws IOException {
-        return resolveLayeredConfigs(MERGE_ACTION.union, MERGE_ACTION.union, configResources);
+        return resolveLayeredConfigs(MERGE_ACTION.union, MERGE_ACTION.keep_extra, configResources);
     }
 
     /**
@@ -886,14 +888,14 @@ public class YAML extends LinkedHashMap<String, Object> {
      * Merges the extra YAML into this YAML.
      * <p>
      * The merge uses {@link MERGE_ACTION#union} aka extra-wins: The values for duplicate keys in YAMLs are merged,
-     * lists are concatenated and atomic values are overwritten with the values from extra.
+     * lists and atomic values are overwritten with the values from extra.
      * <p>
      * Shallow copying is used when possible, so updates to extra after the merge is strongly discouraged.
      * @param extra the YAML that will be added to this.
      * @return this YAML, updated with the values from extra.
      */
     public YAML merge(YAML extra) {
-        return merge(this, extra, MERGE_ACTION.union, MERGE_ACTION.union);
+        return merge(this, extra, MERGE_ACTION.union, MERGE_ACTION.keep_extra);
     }
 
     /**
@@ -913,8 +915,8 @@ public class YAML extends LinkedHashMap<String, Object> {
 
     /**
      * Merges the extra YAML into the base YAML.
-     * The merge uses union/extra-wins: The values for duplicate keys in YAMLs are merged, lists are concatenated
-     * and atomic values are overwritten with the values from extra.
+     * The merge uses union/extra-wins: The values for duplicate keys in YAMLs are merged, lists and atomic values are
+     * overwritten with the values from extra.
      * <p>
      * Shallow copying is used when possible, so updates to extra after the merge is strongly discouraged.
      * @param base the YAML that will be updated with the content from extra.
@@ -922,7 +924,7 @@ public class YAML extends LinkedHashMap<String, Object> {
      * @return the updated base YAML.
      */
     public static YAML merge(YAML base, YAML extra) {
-        return merge(base, extra, MERGE_ACTION.union, MERGE_ACTION.union);
+        return merge(base, extra, MERGE_ACTION.union, MERGE_ACTION.keep_extra);
     }
 
     /**
@@ -1003,7 +1005,6 @@ public class YAML extends LinkedHashMap<String, Object> {
             return;
         }
         base.put(key, mergeEntry(path + "." + key, base.get(key), value, defaultMA, listMA));
-
     }
 
 

--- a/src/main/java/dk/kb/util/yaml/YAML.java
+++ b/src/main/java/dk/kb/util/yaml/YAML.java
@@ -36,6 +36,22 @@ import java.util.stream.Collectors;
 
 /**
  * Wrapper for SnakeYAML output for easier access to the YAML elements.
+ * <p>
+ * Primary use case is for configuration files, using either of
+ * <ul>
+ *     <li>{@link #resolveLayeredConfigs(String...)} which treats multiple files as separate YAMLs, where the content
+ *     of the YAMLs is merged and atomic values are overwritten with the latest file</li>
+ *     <li>{@link #resolveMultiConfig(String...)} which treats multiple files as a single YAML allowing for
+ *     cross referencing inside of the YAML parts</li>
+ * </ul>
+ * <p>
+ * For standard use, the {@link #resolveLayeredConfigs(String...)} is recommended as it makes it simple to layer the
+ * configurations:
+ * <ol>
+ *     <li>myapp_behaviour.yaml (base behaviour settings, goes into the main repo)</li>
+ *     <li>myapp_environment.yaml (servers, usernames, passwords..., is controlled by Operations)</li>
+ *     <li>myapp_local_overrides.yaml (local overrides, used for developing and testing)</li>
+ * </ol>
  */
 public class YAML extends LinkedHashMap<String, Object> {
 

--- a/src/main/java/dk/kb/util/yaml/YAML.java
+++ b/src/main/java/dk/kb/util/yaml/YAML.java
@@ -929,6 +929,13 @@ public class YAML extends LinkedHashMap<String, Object> {
      * Merges the extra YAML into the base YAML. In case of key collisions, the stated merge actions are taken.
      * <p>
      * Shallow copying is used when possible, so updates to extra after the merge is strongly discouraged.
+     * <p>
+     * The available MERGE_ACTIONs are<br>
+     * union: Duplicate maps are merged, lists are concatenated, atomics are overwritten by last entry.<br>
+     * keep_base: Duplicate maps, lists and atomics are ignored.<br>
+     * keep_extra: Duplicate maps, lists and atomics are overwrittes, so that the last encounterd key-value pair wins.<br>
+     * fail: Duplicate maps, lists and atomics throws an exception.<br>
+     *
      * @param base the YAML that will be updated with the content from extra.
      * @param extra the YAML that will be added to base.
      * @param defaultMA the general action to take when a key collision is encountered. Also used for maps (YAMLs)
@@ -984,7 +991,7 @@ public class YAML extends LinkedHashMap<String, Object> {
                     pre + ": Duplicate keys with merge action " + MERGE_ACTION.fail);
             case keep_base: return base;
             case keep_extra: return extra;
-            case union: return extra; // TODO: Should we do somthing else here? Make a type-aware merger? Fail?
+            case union: return extra; // TODO: Should we do something else here? Make a type-aware merger? Fail?
             default: throw new UnsupportedOperationException("Unknown merge action '" + defaultMA + "'");
         }
     }
@@ -1002,7 +1009,7 @@ public class YAML extends LinkedHashMap<String, Object> {
 
     public enum MERGE_ACTION {
         /**
-         * Duplicate maps are merged, lists are concatenated, atomins are overwritten by last entry
+         * Duplicate maps are merged, lists are concatenated, atomics are overwritten by last entry
          */
         union,
         /**

--- a/src/test/java/dk/kb/util/yaml/YAMLTest.java
+++ b/src/test/java/dk/kb/util/yaml/YAMLTest.java
@@ -105,6 +105,21 @@ class YAMLTest {
     }
 
     @Test
+    public void testMerge() throws IOException {
+        final String FIRST_ONLY = "upperA.subYAML.sub2Element";
+        assertTrue(YAML.resolveMultiConfig("yaml/overwrite-1.yaml").containsKey(FIRST_ONLY),
+                   "Non-merged first file should contain element '" + FIRST_ONLY + "'");
+
+        YAML yaml = YAML.resolveMultiConfig("yaml/overwrite-1.yaml", "yaml/overwrite-2.yaml");
+        assertEquals("baz", yaml.getString("upperA.subElement"),
+                     "Merged YAML should contain overwritten element 'upperA.subElement'");
+        assertEquals("bar", yaml.getString(FIRST_ONLY),
+                     "Merged YAML should contain element '" + FIRST_ONLY + "' from file #1");
+        assertEquals(12, yaml.getInteger("upperC.subCElement"),
+                     "Merged YAML should contain element 'upperC.subClement' from file #2");
+    }
+
+    @Test
     public void testFailingMultiConfig() throws IOException {
         Assertions.assertThrows(FileNotFoundException.class,
                                 () -> YAML.resolveMultiConfig("Not_there.yml", "Not_there_2.yml"),

--- a/src/test/java/dk/kb/util/yaml/YAMLTest.java
+++ b/src/test/java/dk/kb/util/yaml/YAMLTest.java
@@ -105,9 +105,9 @@ class YAMLTest {
     }
 
     @Test
-    public void testMerge() throws IOException {
+    public void testLayeredConfigs() throws IOException {
         final String FIRST_ONLY = "upperA.subYAML.sub2Element";
-        assertTrue(YAML.resolveMultiConfig("yaml/overwrite-1.yaml").containsKey(FIRST_ONLY),
+        assertTrue(YAML.resolveLayeredConfigs("yaml/overwrite-1.yaml").containsKey(FIRST_ONLY),
                    "Non-merged first file should contain element '" + FIRST_ONLY + "'");
 
         YAML yaml = YAML.resolveMultiConfig("yaml/overwrite-1.yaml", "yaml/overwrite-2.yaml");

--- a/src/test/java/dk/kb/util/yaml/YAMLTest.java
+++ b/src/test/java/dk/kb/util/yaml/YAMLTest.java
@@ -123,9 +123,9 @@ class YAMLTest {
                      "Merged YAML should contain element 'upperC.subClement' from file #2");
 
         List<String> aList = multi.getList("upperA.subList");
-        List<String> eList = Arrays.asList("one", "two", "three", "four");
+        List<String> eList = Arrays.asList("three", "four");
         assertEquals(eList, aList,
-                     "Merged YAML should a list of concatenated elements");
+                     "Merged YAML should contain the last list");
     }
 
     @Test


### PR DESCRIPTION
Previously using multiple YAML files, e.g. for having a `behaviour-yaml` and an `environment.yaml`-configuration, worked poorly as the YAML files were not merged recursively: Key-collision at the root level meant that the full sub-tree was overwritten.

This pull request makes multi-YAML resolving behaviour explicit. the choices are now
 * `resolveLayeredConfigs`, which treats multiple files as separate YAMLs, where the content of the YAMLs is merged and atomic values are overwritten with the latest file
 * `resolveMultiConfig`, which treats multiple files as a single YAML allowing for cross referencing inside of the YAML parts, but where key-collisions at the root level means the full sub-tree is overwritten with the latest value

`resolveMultiConfig` is the old behaviour and the class constructor as well as the old generic `resolveConfig` uses this, to keep backwards compatibility. 