### PR TITLE
These dependencies are nessesary to prevent errors like these

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,16 +158,23 @@
 
         <!--XML-->
         <!--Nessesary for jaxb-xml with java 11-->
+        <!-- https://mvnrepository.com/artifact/jakarta.xml.bind/jakarta.xml.bind-api -->
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>2.3.3</version>
+            <version>2.3.2</version>
         </dependency>
-
+        <!-- https://mvnrepository.com/artifact/jakarta.activation/jakarta.activation-api -->
+        <dependency>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
+            <version>1.2.1</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.glassfish.jaxb/jaxb-runtime -->
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
-            <version>2.3.3</version>
+            <version>2.3.2</version>
             <scope>runtime</scope>
         </dependency>
         <!--XML end-->


### PR DESCRIPTION
Error occurred during initialization of boot layer
java.lang.module.FindException: Two versions of module jakarta.activation found in /home/abr/Projects/java-xcorrsound/java-xcorrsound-cli/target/java-xcorrsound-cli-0.1-SNAPSHOT/bin/../lib (jakarta.activation-api-1.2.2.jar and jakarta.activation-1.2.2.jar)

For unknown reasons, this does NOT fail when using these specific versions