### PR TITLE
Ported callback escaper and XML escape sanitizer from ds-datahandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
 
+- `CallbackReplacer` and `XMLEscapeSanitiser`: Regexp-based replacements with callbacks
 
 ## [1.4.5](https://github.com/kb-dk/kb-util/tree/kb-util-1.4.5)
+### Added
 
-###
+- Added `StringListUtils.toModifiableList(list)` utility to check, and, if nessesary, wrap your list as a modifiable list
 
-Fixed JSON.java to correctly handle java 8 datetime objects
+### Changed
 
-Added `StringListUtils.toModifiableList(list)` utility to check, and, if nessesary, wrap your list as a modifiable list
-
-
+- Fixed JSON.java to correctly handle java 8 datetime objects
 
 ## [1.4.4](https://github.com/kb-dk/kb-util/tree/kb-util-1.4.4)
 

--- a/src/main/java/dk/kb/util/string/CallbackReplacer.java
+++ b/src/main/java/dk/kb/util/string/CallbackReplacer.java
@@ -1,0 +1,112 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package dk.kb.util.string;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.Locale;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Sub-strings matching a given regular expression are delivered to a callback that returns the replacement string.
+ */
+// TODO: Make this truly streaming using a buffered reader that maps to CharSequence
+public class CallbackReplacer implements Function<String, String> {
+    private final Pattern pattern;
+    private final Function<String, String> callback;
+
+    /**
+     * @param pattern the pattern to look for.
+     *                If the pattern contains no groups, the full match is passed to the callback.
+     *                f it contains a single capturing group, the content of that group is passed to the callback.
+     *                More than 1 group is not supported.
+     * @param callback optionally adjusts the part matching the pattern. Returning null is the same as the empty String.
+     */
+    public CallbackReplacer(String pattern, Function<String, String> callback) {
+        this(Pattern.compile(pattern), callback);
+    }
+
+    /**
+     * @param pattern the pattern to look for.
+     *                If the pattern contains no groups, the full match is passed to the callback.
+     *                f it contains a single capturing group, the content of that group is passed to the callback.
+     *                More than 1 group is not supported.
+     * @param callback optionally adjusts the part matching the pattern. Returning null is the same as the empty String.
+     */
+    public CallbackReplacer(Pattern pattern, Function<String, String> callback) {
+        this.pattern = pattern;
+        this.callback = callback;
+        final int groups = pattern.matcher("").groupCount();
+        if (groups > 1) {
+            throw new UnsupportedOperationException(String.format(
+                    Locale.ROOT,  "The Pattern '%s' has %d capturing groups, while only 0 or 1 group is supported",
+                    pattern.pattern(), groups));
+        }
+    }
+
+    /**
+     * Replaces {@link #pattern} matches in s with the result of calling {@link #callback} with the match.
+     * @param s an input string for replacements.
+     * @return thre result of replacing all matches in s.
+     */
+    @Override
+    public String apply(String s) {
+        Writer out = new StringWriter();
+        try {
+            apply(s, out);
+        } catch (Exception e) {
+            throw new RuntimeException("Exception during replacement", e);
+        }
+        return out.toString();
+    }
+
+    /**
+     * Replaces {@link #pattern} matches in s with the result of calling {@link #callback} with the match.
+     * @param in an input string for replacements.
+     * @param out the result is written here. {@link Writer#flush()} and {@link Writer#flush()} are not called.
+     */
+    public void apply(String in, Writer out) throws IOException {
+        Matcher matcher = pattern.matcher(in);
+        int begin = 0;
+        while (matcher.find()) {
+            out.write(in.substring(begin, matcher.start())); // Copy up to the beginning of the match
+
+            String replacement;
+            // If there is a group in the Pattern, use the content of that one, else use the full match
+            if (matcher.groupCount() == 0) { // No group
+                replacement = callback.apply(matcher.group());
+                out.write(replacement == null ? "" : replacement);
+            } else if (matcher.groupCount() == 1) {
+                replacement = callback.apply(matcher.group(1));
+                out.write(in.substring(matcher.start(), matcher.start(1)));
+                out.write(replacement == null ? "" : replacement);
+                out.write(in.substring(matcher.end(1), matcher.end()));
+            } else {
+                throw new IllegalStateException(
+                        "More that 1 capturing group is not supported. Pattern: '" + pattern.pattern() + "'");
+            }
+            begin = matcher.end();
+        }
+        out.write(in.substring(begin)); // Copy from eht end of last match to the end of the input
+    }
+
+    @Override
+    public String toString() {
+        return "CallbackReplacer(pattern='" + pattern.pattern() + "')";
+    }
+}

--- a/src/main/java/dk/kb/util/xml/XMLEscapeSanitiser.java
+++ b/src/main/java/dk/kb/util/xml/XMLEscapeSanitiser.java
@@ -1,0 +1,116 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package dk.kb.util.xml;
+
+import dk.kb.util.string.CallbackReplacer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.function.Function;
+import java.util.regex.Pattern;
+
+/**
+ * Checks input for XML-escapes, e.g. {@code &#xABCD;} or {@code &#12345;}.
+ * If an escape refers to an illegal XML character (https://en.wikipedia.org/wiki/Valid_characters_in_XML), it is
+ * replaced with '?' or a custom String specified in the constructor. If it is not illegal, the escape is left as-is.
+ *
+ * This sanitizer is conservative and allows only the Non-restricted characters stated on the wikipedia page linked
+ * above. This should ensure maximum interoperability.
+ *
+ * The sanitizer is lenient with regard to syntactical errors in the input. It does not try to fix non-valid constructs
+ * such as {@code &#0A;} (hex in a decimal escape) but instead returns the original input.
+ */
+public class XMLEscapeSanitiser extends CallbackReplacer {
+    private static final Logger log = LoggerFactory.getLogger(XMLEscapeSanitiser.class);
+    private static final Pattern ESCAPE = Pattern.compile("&#x?[a-fA-F0-9]+;");
+
+    /**
+     * Constructs an XML unicode escape validator, where illegal XML codepoints are replaced with {@code ?}.
+     */
+    public XMLEscapeSanitiser() {
+        this("?");
+    }
+
+    /**
+     * Constructs an XML unicode escape validator.
+     * @param replacement returned if an illegal XSML Unicode codepoint is encountered.
+     */
+    public XMLEscapeSanitiser(String replacement) {
+        super(ESCAPE, getEscapeSanitizer(replacement));
+    }
+
+    /**
+     * Isolates the unicode part of an XML escape (either hex or decimal) and parses that to a long, then checks if the
+     * Unicode codepoint is a valid XML character. If it is valid, the full original escape is returned, else the
+     * replacement character (default {@code ?} is returned.
+     * @param replacement the replacement character for illegal XML characters.
+     * @return the original input if the Unicode escape is a valid XML character, else the replacement string.
+     */
+    public static Function<String, String> getEscapeSanitizer(final String replacement) {
+        return escape -> { // &#xABCD; or &#12345; (or &#xAB etc.)
+            try {
+                long unicode;
+                try {
+                    if (escape.charAt(2) == 'x') { // &#xABCD;
+                        unicode = Long.parseLong(escape.substring(3, escape.length() - 1), 16); // &#xABCD; -> ABCD
+                    } else { // &#12345;
+                        unicode = Long.parseLong(escape.substring(2, escape.length() - 1)); // &#12345; -> 12345
+                    }
+                } catch (Exception e) {
+                    log.trace("Syntactically invalid escape '{}'. Returning unmodified", escape);
+                    return escape;
+                }
+
+                // https://en.wikipedia.org/wiki/Valid_characters_in_XML#Non-restricted_characters
+                if ((unicode == 0x9) ||                               // C0 control character: Horizontal tab (TAB)
+                    (unicode == 0xA) ||                               // C0 control character: Line feed (LF aka NL)
+                    (unicode == 0xD) ||                               // C0 control character: Carriage return (CR)
+                    ((unicode >= 0x20) && (unicode <= 0x7E)) ||       // Basic Latin block
+                    (unicode == 0x85) ||                              // C1 control character: Next line (NEL)
+                    ((unicode >= 0xA0) && (unicode <= 0xD7FF)) ||     // Basic Multilingual Plane
+                    ((unicode >= 0xE000) && (unicode <= 0xFDCF)) ||   // Basic Multilingual Plane
+                    ((unicode >= 0xFDF0) && (unicode <= 0xFFFD)) ||   // Basic Multilingual Plane
+                    ((unicode >= 0x10000) && (unicode <= 0x1FFFD)) || // Supplementing planes
+                    ((unicode >= 0x20000) && (unicode <= 0x2FFFD)) ||
+                    ((unicode >= 0x30000) && (unicode <= 0x3FFFD)) ||
+                    ((unicode >= 0x40000) && (unicode <= 0x4FFFD)) ||
+                    ((unicode >= 0x50000) && (unicode <= 0x5FFFD)) ||
+                    ((unicode >= 0x60000) && (unicode <= 0x6FFFD)) ||
+                    ((unicode >= 0x70000) && (unicode <= 0x7FFFD)) ||
+                    ((unicode >= 0x80000) && (unicode <= 0x8FFFD)) ||
+                    ((unicode >= 0x90000) && (unicode <= 0x9FFFD)) ||
+                    ((unicode >= 0xA0000) && (unicode <= 0xAFFFD)) ||
+                    ((unicode >= 0xB0000) && (unicode <= 0xBFFFD)) ||
+                    ((unicode >= 0xC0000) && (unicode <= 0xCFFFD)) ||
+                    ((unicode >= 0xD0000) && (unicode <= 0xDFFFD)) ||
+                    ((unicode >= 0xE0000) && (unicode <= 0xEFFFD)) ||
+                    ((unicode >= 0xF0000) && (unicode <= 0xFFFFD)) ||
+                    ((unicode >= 0x100000) && (unicode <= 0x10FFFD))) {
+                    return escape; // All OK
+                }
+                log.trace("Illegal XML escape character '" + escape + "'");
+                return replacement;
+            } catch (Exception e) {
+                log.warn("Exception processing '" + escape + "'", e);
+            }
+            return null;
+        };
+    }
+
+    @Override
+    public String toString() {
+        return "XMLEscapeSanitiser(" + super.toString() + ")";
+    }
+}

--- a/src/test/java/dk/kb/util/string/CallbackReplacerTest.java
+++ b/src/test/java/dk/kb/util/string/CallbackReplacerTest.java
@@ -1,0 +1,96 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package dk.kb.util.string;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.regex.Pattern;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CallbackReplacerTest {
+
+    @Test
+    void basicReplace() {
+         CallbackReplacer allAs = new CallbackReplacer(
+                 "a+", s -> "A");
+         assertEquals("AnAnAs",
+                      allAs.apply("anaaanas"));
+    }
+
+    @Test
+    void basicReplacePattern() {
+         CallbackReplacer allAs = new CallbackReplacer(
+                 Pattern.compile("a+"), s -> "A");
+         assertEquals("AnAnAs",
+                      allAs.apply("anaaanas"));
+    }
+
+    @Test
+    void callbackLogic() {
+         CallbackReplacer halver = new CallbackReplacer(
+                 "[0-9]+", s -> Integer.toString((Integer.parseInt(s)/2)));
+         assertEquals("Here are 2 apples and 1024 oranges",
+                      halver.apply("Here are 4 apples and 2048 oranges"));
+    }
+
+    @Test
+    void captureGroup() {
+         CallbackReplacer halver = new CallbackReplacer(
+                 Pattern.compile("[a-z]=([0-9]+)"), s -> Integer.toString((Integer.parseInt(s)/2)));
+         assertEquals("Person 1 says a=5 and person 2 says a=10",
+                      halver.apply("Person 1 says a=10 and person 2 says a=20"));
+    }
+
+    @SuppressWarnings("RegExpUnnecessaryNonCapturingGroup")
+    @Test
+    void nonCaptureGroup() {
+         CallbackReplacer halver = new CallbackReplacer(
+                 Pattern.compile("(?:[a-z])=([0-9]+)"), s -> Integer.toString((Integer.parseInt(s)/2)));
+         assertEquals("Person 1 says a=5 and person 2 says a=10",
+                      halver.apply("Person 1 says a=10 and person 2 says a=20"));
+    }
+
+    @Test
+    void captureGroupNoMatch() {
+         CallbackReplacer halver = new CallbackReplacer(
+                 Pattern.compile("[a-z]=([0-9]+)"), s -> Integer.toString((Integer.parseInt(s)/2)));
+         assertEquals("Person 1 says a=A1 and person 2 says a=A2",
+                      halver.apply("Person 1 says a=A1 and person 2 says a=A2"));
+    }
+
+    @Test
+    void captureGroupFail() {
+         try {
+             new CallbackReplacer(
+                     Pattern.compile("[a-z]=([0-9]+)(a-z)"), s -> Integer.toString((Integer.parseInt(s)/2)));
+             throw new IllegalStateException("More than 1 capturing group is not expected to be supported");
+         } catch (Exception e) {
+             // Expected
+         }
+    }
+    
+    @Test
+    void streamingOutput() throws IOException {
+        StringWriter out = new StringWriter();
+        CallbackReplacer halver = new CallbackReplacer(
+                "[0-9]+", s -> Integer.toString((Integer.parseInt(s)/2)));
+        halver.apply("foo=12", out);
+        String result = out.toString();
+        assertEquals("foo=6", result);
+    }
+}

--- a/src/test/java/dk/kb/util/xml/XMLEscapeSanitiserTest.java
+++ b/src/test/java/dk/kb/util/xml/XMLEscapeSanitiserTest.java
@@ -1,0 +1,81 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package dk.kb.util.xml;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class XMLEscapeSanitiserTest {
+
+    @Test
+    void noEscape() {
+        assertEquals("<foo>Barbarian</foo>", escape("<foo>Barbarian</foo>"));
+    }
+
+    @Test
+    void noEscapeNewlineHex1() {
+        assertEquals("<foo>Barbarian&#x0A;</foo>", escape("<foo>Barbarian&#x0A;</foo>"));
+    }
+
+    @Test
+    void badlyEscaped() {
+        assertEquals("<foo>Barbarian&#0A;</foo>", escape("<foo>Barbarian&#0A;</foo>"));
+    }
+
+    @Test
+    void noEscapeNewlineHex2() {
+        assertEquals("<foo>Barbarian&#x000A;</foo>", escape("<foo>Barbarian&#x000A;</foo>"));
+    }
+
+    @Test
+    void noEscapeNewlineDec() {
+        assertEquals("<foo>Barbarian&#10;</foo>", escape("<foo>Barbarian&#10;</foo>"));
+    }
+
+    @Test
+    void lowEscapeHex() {
+        assertEquals("<foo>Barbarian?</foo>", escape("<foo>Barbarian&#x0;</foo>"));
+    }
+
+    @Test
+    void lowEscapeDec() {
+        assertEquals("<foo>Barbarian?</foo>", escape("<foo>Barbarian&#7;</foo>"));
+    }
+
+    @Test
+    void highEscapeHex() {
+        assertEquals("<foo>Barbarian?</foo>", escape("<foo>Barbarian&#xFDD0;</foo>"));
+    }
+
+    @Test
+    void highEscapeHexLowercase() {
+        assertEquals("<foo>Barbarian?</foo>", escape("<foo>Barbarian&#xfdd0;</foo>"));
+    }
+
+    @Test
+    void extendedEscapeOK() {
+        assertEquals("<foo>Barbarian&#x10FFFD;</foo>", escape("<foo>Barbarian&#x10FFFD;</foo>"));
+    }
+
+    @Test
+    void extendedEscapeIllegal() {
+        assertEquals("<foo>Barbarian?</foo>", escape("<foo>Barbarian&#x10FFFE;</foo>"));
+    }
+
+    private String escape(String xml) {
+        return new XMLEscapeSanitiser().apply(xml);
+    }
+}


### PR DESCRIPTION
When XML character escapes, e.g. `&#x0A;`, refers to Unicode codepoints not supported by XML, some XMl frameworks fail with an Exception. This pull request adds the `XMLEscapeSanitizer` which replaces such escapes with `?`. As part of that, the generic regexp- and callback-oriented `CallbackReplacer` is introduced.

This code is ported and extended from https://github.com/kb-dk/ds-datahandler . More unit-tests has been added, but the only functional change is a more precise check for allowed XML characters where the list is taken from https://en.wikipedia.org/wiki/Valid_characters_in_XML#Non-restricted_characters