### PR TITLE
Yaml.toString() outputs yaml

### DIFF
--- a/src/main/java/dk/kb/util/yaml/YAML.java
+++ b/src/main/java/dk/kb/util/yaml/YAML.java
@@ -17,6 +17,7 @@ package dk.kb.util.yaml;
 import dk.kb.util.Resolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 
 import javax.validation.constraints.NotNull;
@@ -24,12 +25,17 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
 import java.io.SequenceInputStream;
+import java.net.MalformedURLException;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -1008,7 +1014,15 @@ public class YAML extends LinkedHashMap<String, Object> {
         }
         base.put(key, mergeEntry(path + "." + key, base.get(key), value, defaultMA, listMA));
     }
-
+    
+    public String toString(){
+        DumperOptions dumperOptions = new DumperOptions();
+        dumperOptions.setIndentWithIndicator(true);
+        dumperOptions.setIndicatorIndent(2);
+        dumperOptions.setProcessComments(true);
+        // dumperOptions.setPrettyFlow(true);
+        return new Yaml(dumperOptions).dumpAs(this, null, DumperOptions.FlowStyle.BLOCK);
+    }
 
     public enum MERGE_ACTION {
         /**

--- a/src/test/java/dk/kb/util/yaml/YAMLTest.java
+++ b/src/test/java/dk/kb/util/yaml/YAMLTest.java
@@ -1,5 +1,6 @@
 package dk.kb.util.yaml;
 
+import dk.kb.util.Resolver;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -15,11 +16,25 @@ import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 class YAMLTest {
+    @Test
+    public void testToString() throws IOException {
+        String contents = Files.readAllLines(Resolver.getPathFromClasspath("test.yml"))
+                               .stream()
+                               .map(line -> line.replaceAll("#.*$", "").stripTrailing())
+                               .filter(line -> !line.isBlank())
+                               .collect(Collectors.joining("\n")) + "\n";
+        assertEquals(contents, YAML.resolveLayeredConfigs("test.yml").toString());
+    }
+    
+    
     @Test
     public void testLoad() throws IOException {
         YAML.resolveLayeredConfigs("test.yml").getSubMap("test");
@@ -56,7 +71,7 @@ class YAMLTest {
     @Test
     public void testKeptPath() throws IOException {
         YAML yaml = YAML.resolveLayeredConfigs("test.yml").getSubMap("test");
-        assertEquals("{nested.sublevel2string=sub1}", yaml.getSubMap("nested",true).toString(),
+        assertEquals("nested.sublevel2string: sub1\n", yaml.getSubMap("nested",true).toString(),
                      "When we get map with subkeys preserved, we should see the nested previs");
     }
     


### PR DESCRIPTION
So that we can recreate a yaml document from the YAML objects. I needed it for a case where I had to output something as JSON, and had a library that could convert a YAML string to a JSON string. 