### PR TITLE
Wrap Files.list in try-catch to avoid file handle leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Fix resource leak in `Resolver#walkMatches`
+
 ## [1.4.5](https://github.com/kb-dk/kb-util/tree/kb-util-1.4.5)
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `CallbackReplacer` and `XMLEscapeSanitiser`: Regexp-based replacements with callbacks
 
+### Changed
+
+- Fix resource leak in `Resolver#walkMatches`
 ## [1.4.5](https://github.com/kb-dk/kb-util/tree/kb-util-1.4.5)
 ### Added
 

--- a/src/main/java/dk/kb/util/Resolver.java
+++ b/src/main/java/dk/kb/util/Resolver.java
@@ -204,10 +204,11 @@ public class Resolver {
             }
             return;
         }
-        try {
-            // List the content of the current folder, recursively descending to the ones matching the relevant
-            // segment from the overall glob
-            Files.list(current).
+        
+        // List the content of the current folder, recursively descending to the ones matching the relevant
+        // segment from the overall glob
+        try (Stream<Path> folderContent = Files.list(current)) { // Must be closed after use
+            folderContent.
                     filter(path -> matchers.get(matchersIndex).matches(path.getFileName())).
                     forEach(path -> walkMatches(path, matchers, matchersIndex+1, consumer));
         } catch (IOException e) {


### PR DESCRIPTION
Using the resolver with globs caused a leak of file handles. Exacerbated in the java-webapp-template that supportes periodic checks for changed files.