### PR TITLE
Add support for splitting Streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - ExtractionUtils focused on sampling and extracting minimum or maximum values from Streams and Collections.
+- Splitting of an incoming Stream to multiple partitions 
 
 ## [1.4.9](https://github.com/kb-dk/kb-util/tree/kb-util-1.4.9)
 ### Added

--- a/src/test/java/dk/kb/util/other/ExtractionUtilsTest.java
+++ b/src/test/java/dk/kb/util/other/ExtractionUtilsTest.java
@@ -40,7 +40,7 @@ class ExtractionUtilsTest {
         assertEquals(2, outLists.get(1).size(), "The second stream should contain a list of the expected size");
         assertEquals(1, outLists.get(2).size(), "The third stream should contain a list of the expected size");
 
-        assertEquals(4, outLists.get(1).get(1), "The second element in the second stream should be correct");
+        assertEquals("[[1, 2], [3, 4], [5]]", outLists.toString(), "The total output should be as expected");
     }
 
     @Test
@@ -57,7 +57,7 @@ class ExtractionUtilsTest {
         assertEquals(2, outLists.get(1).size(), "The second stream should contain a stream of the expected size");
         assertEquals(1, outLists.get(2).size(), "The third stream should contain a stream of the expected size");
 
-        assertEquals(4, outLists.get(1).get(1), "The second element in the second stream should be correct");
+        assertEquals("[[1, 2], [3, 4], [5]]", outLists.toString(), "The total output should be as expected");
     }
 
     @Test

--- a/src/test/java/dk/kb/util/other/ExtractionUtilsTest.java
+++ b/src/test/java/dk/kb/util/other/ExtractionUtilsTest.java
@@ -2,10 +2,12 @@ package dk.kb.util.other;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -24,8 +26,57 @@ import static org.junit.jupiter.api.Assertions.*;
  *  limitations under the License.
  *
  */
-@SuppressWarnings("ArraysAsListWithZeroOrOneArgument")
 class ExtractionUtilsTest {
+
+    @Test
+    void testPartitionList() {
+        Stream<List<Integer>> out = ExtractionUtils.splitToLists(Stream.of(1, 2, 3, 4, 5), 2);
+
+        List<List<Integer>> outLists = out.collect(Collectors.toList());
+
+        assertEquals(3, outLists.size(), "There should be 3 streams in the output");
+
+        assertEquals(2, outLists.get(0).size(), "The first stream should contain a list of the expected size");
+        assertEquals(2, outLists.get(1).size(), "The second stream should contain a list of the expected size");
+        assertEquals(1, outLists.get(2).size(), "The third stream should contain a list of the expected size");
+
+        assertEquals(4, outLists.get(1).get(1), "The second element in the second stream should be correct");
+    }
+
+    @Test
+    void testPartitionStream() {
+        Stream<Stream<Integer>> out = ExtractionUtils.splitToStreams(Stream.of(1, 2, 3, 4, 5), 2);
+
+        List<List<Integer>> outLists = out.
+                map(stream -> stream.collect(Collectors.toList())).
+                collect(Collectors.toList());
+
+        assertEquals(3, outLists.size(), "There should be 3 streams in the output");
+
+        assertEquals(2, outLists.get(0).size(), "The first stream should contain a stream of the expected size");
+        assertEquals(2, outLists.get(1).size(), "The second stream should contain a stream of the expected size");
+        assertEquals(1, outLists.get(2).size(), "The third stream should contain a stream of the expected size");
+
+        assertEquals(4, outLists.get(1).get(1), "The second element in the second stream should be correct");
+    }
+
+    @Test
+    void testPartitionStreamparallel() {
+        Stream<Stream<Integer>> out = ExtractionUtils.splitToStreams(Stream.of(1, 2, 3, 4, 5).parallel(), 2);
+
+        List<List<Integer>> outLists = out.
+                map(stream -> stream.collect(Collectors.toList())).
+                collect(Collectors.toList());
+
+        assertEquals(3, outLists.size(), "There should be 3 streams in the output");
+
+        assertEquals(2, outLists.get(0).size(), "The first stream should contain a stream of the expected size");
+        assertEquals(2, outLists.get(1).size(), "The second stream should contain a stream of the expected size");
+        assertEquals(1, outLists.get(2).size(), "The third stream should contain a stream of the expected size");
+        
+        List<Integer> sorted = outLists.stream().flatMap(Collection::stream).sorted().collect(Collectors.toList());
+        assertEquals("[1, 2, 3, 4, 5]", sorted.toString(), "All values should be present in the output");
+    }
 
     @Test
     void testSample() {


### PR DESCRIPTION
Partitioning/chunking/splitting a Stream is used in multiple projects, e.g. SolrWayback. This pull request adds a generic implementation for that.