### PR TITLE
Exception of unfulfillable expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for positioning an XMLStreamReader at a given XPath, so that the path-matching sub-XML can be processed or extracted
-- Exception thowing on unfulfillable expansion in YAML configs
+- Exception throwing on unfulfillable expansion in YAML configs
 
 ## [1.4.11](https://github.com/kb-dk/kb-util/tree/kb-util-1.4.11)
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for positioning an XMLStreamReader at a given XPath, so that the path-matching sub-XML can be processed or extracted
+- Exception thowing on unfulfillable expansion in YAML configs
 
 ## [1.4.11](https://github.com/kb-dk/kb-util/tree/kb-util-1.4.11)
 ### Added

--- a/Core/src/test/resources/common/configurationFiles/simple_xstorage.xml
+++ b/Core/src/test/resources/common/configurationFiles/simple_xstorage.xml
@@ -1,0 +1,10 @@
+<xproperties>
+    <xproperties>
+        <entry>
+            <key>mykey</key>
+            <value class="string">myvalue</value>
+        </entry>
+    </xproperties>
+</xproperties>
+
+

--- a/src/main/java/dk/kb/util/yaml/YAML.java
+++ b/src/main/java/dk/kb/util/yaml/YAML.java
@@ -80,6 +80,11 @@ import java.util.stream.Collectors;
  * Note: Besides system environment, it is possible to use other substitutions, such as environment variables using
  * the syntax {@code ${env:USERNAME}}. See the JavaDoc for {@link StringSubstitutor} for examples. Where possible,
  * use system environment as that is the least unstable across platforms.
+ *
+ * Note 2: Nested fallbacks is somewhat possible, but works poorly with prefixed lookups. As {@code sys:} is implicit
+ * a working "provide the value either as system properties or environment variables" definition can be written as
+ * {@code ${env:USERNAME:-${user.name:-igiveup}}} where switching {@code env:USERNAME} and {@code user.name} will not
+ * work.
  */
 public class YAML extends LinkedHashMap<String, Object> {
 

--- a/src/main/java/dk/kb/util/yaml/YAML.java
+++ b/src/main/java/dk/kb/util/yaml/YAML.java
@@ -1191,9 +1191,12 @@ public class YAML extends LinkedHashMap<String, Object> {
     static String substitute(String s) {
         synchronized (YAML.class) {
             if (substitutors == null) {
-                substitutors = new ArrayList<>(2);
-                substitutors.add(StringSubstitutor.createInterpolator()); // General prefix based
-                substitutors.add(new StringSubstitutor(StringLookupFactory.INSTANCE.systemPropertyStringLookup()));
+                substitutors = List.of(
+                        // General prefix based
+                        StringSubstitutor.createInterpolator(),
+                        // Default to system property lookup
+                        new StringSubstitutor(StringLookupFactory.INSTANCE.systemPropertyStringLookup()).
+                                setEnableUndefinedVariableException(true));
             }
         }
         for (StringSubstitutor substitutor: substitutors) {

--- a/src/test/java/dk/kb/util/yaml/YAMLTest.java
+++ b/src/test/java/dk/kb/util/yaml/YAMLTest.java
@@ -219,7 +219,7 @@ class YAMLTest {
         YAML yaml = YAML.resolveLayeredConfigs("testExtrapolated.yml").getSubMap("test").extrapolate(true);
         try {
             yaml.getString("exceptionimplicit");
-            fail("Requesting a property with expansion of implicit sys:, where the expansion could not be fullfilled, should throw an Exception");
+            fail("Requesting a property with expansion of implicit sys:, where the expansion could not be fulfilled, should throw an Exception");
         } catch (Exception e) {
             // Expected
         }
@@ -230,7 +230,7 @@ class YAMLTest {
         YAML yaml = YAML.resolveLayeredConfigs("testExtrapolated.yml").getSubMap("test").extrapolate(true);
         try {
             yaml.getString("exceptionenv");
-            fail("Requesting a property with expansion of explicit env:, where the expansion could not be fullfilled, should throw an Exception");
+            fail("Requesting a property with expansion of explicit env:, where the expansion could not be fulfilled, should throw an Exception");
         } catch (Exception e) {
             // Expected
         }

--- a/src/test/resources/testExtrapolated.yml
+++ b/src/test/resources/testExtrapolated.yml
@@ -4,6 +4,8 @@ test:
   someint: ${java.specification.version}
   somedouble: ${java.class.version}
   somebool: true
+  exceptionimplicit: ${nonexisting.property}
+  exceptionenv: ${env:NOT_HERE}
   fallback: ${nonexisting.property:-mydefault}
   envfallback: ${sys:NOT_DEFINED:-envdefault}
   nestedfallback: ${nonexisting:-${user.home:-dontreach}}
@@ -20,7 +22,6 @@ test:
   nestedfallbackfail: ${nonexisting:-${also.nonexisting:-reach}}
   sysuser: ${sys:user.name}
   envuser: ${env:USERNAME}
-  nonexpand: $${raw}
   nested:
     sublevel2string: ${user.name}
   arrayofstrings:

--- a/src/test/resources/testExtrapolated.yml
+++ b/src/test/resources/testExtrapolated.yml
@@ -5,7 +5,22 @@ test:
   somedouble: ${java.class.version}
   somebool: true
   fallback: ${nonexisting.property:-mydefault}
+  envfallback: ${sys:NOT_DEFINED:-envdefault}
+  nestedfallback: ${nonexisting:-${user.home:-dontreach}}
+
+  # Unfortunately nested fallback does not work with prefix, so nestedfallbacksyssys results in "dontreach"
+  nestedfallbacksyssys: ${sys:nonexisting:-${sys:user.home:-dontreach}}
+
+  # Unfortunately nested fallback does not work with prefix, so env-resolving does not work for secondary lookup
+  mixedfallbacksysenv: ${nonexisting:-${env:USERNAME:-dontreach}}
+
+  # This works as the prefix-requiring environment lookup is first in the chain
+  mixedfallbackenvsys: ${env:NONEXISTING:-${user.name:-dontreach}}
+
+  nestedfallbackfail: ${nonexisting:-${also.nonexisting:-reach}}
   sysuser: ${sys:user.name}
+  envuser: ${env:USERNAME}
+  nonexpand: $${raw}
   nested:
     sublevel2string: ${user.name}
   arrayofstrings:


### PR DESCRIPTION
When specifying a YAML value using expansion, such as
```
  database: ${db.url}
```
the `YAML` implementation should throw an Exception if the system property cannot be resolved. This pull request adds that functionality with corresponding unit tests.