### PR TITLE
Path substitution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Path-substitution in YAML, allowing for YAML entries like `dburl: ${path:databases.primary.url}`
+- Conditionals in path in YAML, allowing for Java calls like `myYAML.get("databases.[default=true].url");`
+- Combining path substitution and conditional paths, allowing for YAML entries like `dburl: ${path:databases.[default=true].url}` 
 
 ## [1.4.12](https://github.com/kb-dk/kb-util/tree/kb-util-1.4.12)
 ### Added

--- a/pom.xml
+++ b/pom.xml
@@ -303,6 +303,11 @@
             <version>3.2.4</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.10.0</version>
+        </dependency>
 
 
     </dependencies>

--- a/src/main/java/dk/kb/util/yaml/YAML.java
+++ b/src/main/java/dk/kb/util/yaml/YAML.java
@@ -572,10 +572,14 @@ public class YAML extends LinkedHashMap<String, Object> {
     }
     
     /**
-     * Resolves the Object at the given path in the YAML. Path elements are separated by {@code .} and can be either -
-     * YAML-key for direct traversal, e.g. "foo" or "foo.bar" - YAML-key[index] for a specific element in a list, e.g.
-     * "foo.[2]" or "foo.[2].bar" - YAML-key.[last] for the last element in a list, e.g. "foo.[last]" or "foo.bar.[last]"
-     * Sample path: {@code foo.bar}
+     * Resolves the Object at the given path in the YAML. Path elements are separated by {@code .} and can be either
+     * <ul>
+     * <li>{@code key} for direct traversal, e.g. "foo" or "foo.bar"</li>
+     * <li>{@code key[index]} for a specific element in a list, e.g. "foo.[2]" or "foo.[2].bar"</li>
+     * <li>{@code key.[last]} for the last element in a list, e.g. "foo.[last]" or "foo.bar.[last]"</li>
+     * <li>{@code key.[subkey=value]} for the first map element in a list where its value for the subkey matches, e.g. "foo.[bar=baz]"</li>
+     * <li>{@code key.[subkey!=value]} for the map element in a list where its value for the subkey does not match, e.g. "foo.[bar!=baz]"</li>
+     *  </ul> 
      * Note: Dots {@code .} in YAML keys can be escaped with quotes: {@code foo.'a.b.c' -> [foo, a.b.c]}.
      * <p>
      * Returns this object if the path is empty

--- a/src/test/java/dk/kb/util/yaml/YAMLTest.java
+++ b/src/test/java/dk/kb/util/yaml/YAMLTest.java
@@ -542,19 +542,49 @@ class YAMLTest {
     @Test
     public void testConditionalIndex() throws IOException {
         YAML yaml = YAML.resolveLayeredConfigs("nested_maps.yml");
-        assertEquals("boom", yaml.get("conditionalmap.[default=true].foo"));
+        assertEquals("boom", yaml.get("conditionalpropermap.[default=true].foo"));
+    }
+
+    @Test
+    public void testNonConditionalMap() throws IOException {
+        YAML yaml = YAML.resolveLayeredConfigs("nested_maps.yml");
+        assertEquals("zoo", yaml.get("conditionalpropermap.bucket2.foo"));
+    }
+
+    @Test
+    public void testNonConditionalMapList() throws IOException {
+        YAML yaml = YAML.resolveLayeredConfigs("nested_maps.yml");
+        assertEquals("zoo", yaml.get("conditionalmaplist[1].bucket2.foo"));
     }
 
     @Test
     public void testReverseConditionalIndex() throws IOException {
         YAML yaml = YAML.resolveLayeredConfigs("nested_maps.yml");
-        assertEquals("bar", yaml.get("conditionalmap.[default!=true].foo"));
+        assertEquals("bar", yaml.get("conditionalpropermap.[default!=true].foo"));
     }
 
     @Test
-    public void testConditionalIndexFlat() throws IOException {
+    public void testConditionalIndexProper() throws IOException {
         YAML yaml = YAML.resolveLayeredConfigs("nested_maps.yml");
-        assertEquals("boom", yaml.get("conditionalflat.[default=true].foo"));
+        assertEquals("boom", yaml.get("conditionalpropermap.[default=true].foo"));
+    }
+
+    @Test
+    public void testConditionalMapList() throws IOException {
+        YAML yaml = YAML.resolveLayeredConfigs("nested_maps.yml");
+        assertEquals("boom", yaml.get("conditionalmaplist.[default=true].foo"));
+    }
+
+    @Test
+    public void testConditionalFlatMapList() throws IOException {
+        YAML yaml = YAML.resolveLayeredConfigs("nested_maps.yml");
+        assertEquals("boom", yaml.get("conditionalflatmaplist.[default=true].foo"));
+    }
+
+    @Test
+    public void testConditionalAnonymousMapList() throws IOException {
+        YAML yaml = YAML.resolveLayeredConfigs("nested_maps.yml");
+        assertEquals("boom", yaml.get("conditionalanonymousmaplist.[default=true].foo"));
     }
 
     @Test

--- a/src/test/java/dk/kb/util/yaml/YAMLTest.java
+++ b/src/test/java/dk/kb/util/yaml/YAMLTest.java
@@ -528,4 +528,15 @@ class YAMLTest {
         String actual = yaml.getString(path);
         assertEquals(expected, actual, message);
     }
+
+    @Test
+    public void testPathSubstitute() throws IOException {
+        YAML yaml = YAML.resolveLayeredConfigs("yaml/path_substitution.yaml");
+        yaml.setExtrapolate(true);
+
+        assertEquals("foo", yaml.get(".lower.bar"), "Basic path substitution should work");
+        assertEquals("boom", yaml.get(".fallback.bar"), "Path substitution with default value should work");
+        assertEquals("foo", yaml.get(".mixing.bar"), "Path substitution with default value should work");
+    }
+
 }

--- a/src/test/java/dk/kb/util/yaml/YAMLTest.java
+++ b/src/test/java/dk/kb/util/yaml/YAMLTest.java
@@ -557,4 +557,12 @@ class YAMLTest {
         assertEquals("boom", yaml.get("conditionalflat.[default=true].foo"));
     }
 
+    @Test
+    public void testConditionalPathSubstitute() throws IOException {
+        YAML yaml = YAML.resolveLayeredConfigs("yaml/path_substitution.yaml");
+        yaml.setExtrapolate(true);
+
+        assertEquals("kaboom", yaml.get(".sams.bar"), "Path substitution with conditional path should work");
+    }
+
 }

--- a/src/test/java/dk/kb/util/yaml/YAMLTest.java
+++ b/src/test/java/dk/kb/util/yaml/YAMLTest.java
@@ -539,4 +539,22 @@ class YAMLTest {
         assertEquals("foo", yaml.get(".mixing.bar"), "Path substitution with default value should work");
     }
 
+    @Test
+    public void testConditionalIndex() throws IOException {
+        YAML yaml = YAML.resolveLayeredConfigs("nested_maps.yml");
+        assertEquals("boom", yaml.get("conditionalmap.[default=true].foo"));
+    }
+
+    @Test
+    public void testReverseConditionalIndex() throws IOException {
+        YAML yaml = YAML.resolveLayeredConfigs("nested_maps.yml");
+        assertEquals("bar", yaml.get("conditionalmap.[default!=true].foo"));
+    }
+
+    @Test
+    public void testConditionalIndexFlat() throws IOException {
+        YAML yaml = YAML.resolveLayeredConfigs("nested_maps.yml");
+        assertEquals("boom", yaml.get("conditionalflat.[default=true].foo"));
+    }
+
 }

--- a/src/test/java/dk/kb/util/yaml/YAMLUtilsTest.java
+++ b/src/test/java/dk/kb/util/yaml/YAMLUtilsTest.java
@@ -87,14 +87,4 @@ class YAMLUtilsTest {
                      flattenedValues);
     }
 
-    @Test
-    public void testPathSubstitute() throws IOException {
-        YAML yaml = YAML.resolveLayeredConfigs("yaml/path_substitution.yaml");
-        yaml.setExtrapolate(true);
-
-        assertEquals("foo", yaml.get(".lower.bar"), "Basic path substitution should work");
-        assertEquals("boom", yaml.get(".fallback.bar"), "Path substitution with default value should work");
-        assertEquals("foo", yaml.get(".mixing.bar"), "Path substitution with default value should work");
-    }
-
 }

--- a/src/test/java/dk/kb/util/yaml/YAMLUtilsTest.java
+++ b/src/test/java/dk/kb/util/yaml/YAMLUtilsTest.java
@@ -87,4 +87,14 @@ class YAMLUtilsTest {
                      flattenedValues);
     }
 
+    @Test
+    public void testPathSubstitute() throws IOException {
+        YAML yaml = YAML.resolveLayeredConfigs("yaml/path_substitution.yaml");
+        yaml.setExtrapolate(true);
+
+        assertEquals("foo", yaml.get(".lower.bar"), "Basic path substitution should work");
+        assertEquals("boom", yaml.get(".fallback.bar"), "Path substitution with default value should work");
+        assertEquals("foo", yaml.get(".mixing.bar"), "Path substitution with default value should work");
+    }
+
 }

--- a/src/test/resources/nested_maps.yml
+++ b/src/test/resources/nested_maps.yml
@@ -4,3 +4,35 @@ test:
     - fooA1: barA1
       fooA2: barA2
     - fooB: barB
+
+conditionalmap:
+  - bucket1:
+      foo: bar
+      # Note: No default defined
+
+  - bucket2:
+      foo: zoo
+      default: false
+
+  - bucket3:
+      foo: boom
+      default: true
+
+  - bucket4:
+      foo: baz
+
+conditionalflat:
+  - bucket1:
+    foo: bar
+      # Note: No default defined
+
+  - bucket1:
+    foo: zoo
+    default: false
+
+  - bucket3:
+    foo: boom
+    default: true
+
+  - bucket4:
+    foo: baz

--- a/src/test/resources/nested_maps.yml
+++ b/src/test/resources/nested_maps.yml
@@ -5,34 +5,62 @@ test:
       fooA2: barA2
     - fooB: barB
 
-conditionalmap:
+# Nested map structure
+# Very common way of stating strucctures in YAML
+conditionalpropermap:
+  bucket1:
+    foo: bar
+    # Note: No default defined
+  bucket2:
+    foo: zoo
+    default: false
+  bucket3:
+    foo: boom
+    default: true
+  bucket4:
+    foo: baz
+
+# List of maps containing submaps
+# Not a clean way of writing YAML, but it happens
+conditionalmaplist:
   - bucket1:
       foo: bar
       # Note: No default defined
-
   - bucket2:
       foo: zoo
       default: false
-
   - bucket3:
       foo: boom
       default: true
-
   - bucket4:
       foo: baz
 
-conditionalflat:
+# List of maps containing values
+# A bit cleaner than conditionalmaplist, but still a strange design
+conditionalflatmaplist:
   - bucket1:
     foo: bar
-      # Note: No default defined
-
-  - bucket1:
+    # Note: No default defined
+  - bucket2:
     foo: zoo
     default: false
-
   - bucket3:
     foo: boom
     default: true
-
   - bucket4:
+    foo: baz
+
+# List of maps containing values below, without map id as explicit key
+# A common & sane YAML construction
+conditionalanonymousmaplist:
+  - name: bucket1
+    foo: bar
+    # Note: No default defined
+  - name: bucket2
+    foo: zoo
+    default: false
+  - name: bucket3
+    foo: boom
+    default: true
+  - name: bucket4
     foo: baz

--- a/src/test/resources/yaml/path_substitution.yaml
+++ b/src/test/resources/yaml/path_substitution.yaml
@@ -1,0 +1,14 @@
+upper:
+  sub1: foo
+
+middle:
+  zoo: ${user.home}
+
+lower:
+  bar: "${path:upper.sub1}"
+
+fallback:
+  bar: "${path:upper.nothere:-boom}"
+
+mixing:
+  bar: "${env:NONEXISTING:-${path:upper.sub1}}"

--- a/src/test/resources/yaml/path_substitution.yaml
+++ b/src/test/resources/yaml/path_substitution.yaml
@@ -16,18 +16,19 @@ mixing:
 sams:
   bar: "${path:conditionalmap[default=true].foo}"
 
+# Proper map below
 conditionalmap:
-  - bucket1:
-      foo: bar
-      # Note: No default defined
+  bucket1:
+    foo: bar
+    # Note: No default defined
 
-  - bucket2:
-      foo: zoo
-      default: false
+  bucket2:
+    foo: zoo
+    default: false
 
-  - bucket3:
-      foo: kaboom
-      default: true
+  bucket3:
+    foo: kaboom
+    default: true
 
-  - bucket4:
-      foo: baz
+  bucket4:
+    foo: baz

--- a/src/test/resources/yaml/path_substitution.yaml
+++ b/src/test/resources/yaml/path_substitution.yaml
@@ -12,3 +12,22 @@ fallback:
 
 mixing:
   bar: "${env:NONEXISTING:-${path:upper.sub1}}"
+
+sams:
+  bar: "${path:conditionalmap[default=true].foo}"
+
+conditionalmap:
+  - bucket1:
+      foo: bar
+      # Note: No default defined
+
+  - bucket2:
+      foo: zoo
+      default: false
+
+  - bucket3:
+      foo: kaboom
+      default: true
+
+  - bucket4:
+      foo: baz


### PR DESCRIPTION
This pull request makes it possible to perform path substitution (simple values only - for now). Besides the example given in #43  it is possible to make a conditional substitution such as
```
databases:
  - production:
    -  url: http://example.com/prod"
  - test:
    -  url: http://example.com/test"
    - default: true

newservice:
  threads: 16
  databaseurl: ${path:databases[default=true].url}
```

This closes #43 