### PR TITLE
Bugfix: Path substitution did nor work properly with YAML.getSubMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Added
+### Bugfix
+- Path-substitution failed when using `YAML.getSubMap(...)` and requesting a key with a substitution using value.
 
 ## [1.4.13](https://github.com/kb-dk/kb-util/tree/kb-util-1.4.13)
 ### Added

--- a/src/test/java/dk/kb/util/yaml/YAMLTest.java
+++ b/src/test/java/dk/kb/util/yaml/YAMLTest.java
@@ -595,4 +595,12 @@ class YAMLTest {
         assertEquals("kaboom", yaml.get(".sams.bar"), "Path substitution with conditional path should work");
     }
 
+    @Test
+    public void testSubMapPath() throws IOException {
+        YAML yaml = YAML.resolveLayeredConfigs("nested_maps.yml");
+        yaml.setExtrapolate(true);
+
+        assertEquals("boom", yaml.get("nested.inner.foosubst"), "Getting by full path should work");
+        assertEquals("boom", yaml.getSubMap("nested").get("inner.foosubst"), "Getting from submap should work");
+    }
 }

--- a/src/test/resources/nested_maps.yml
+++ b/src/test/resources/nested_maps.yml
@@ -64,3 +64,8 @@ conditionalanonymousmaplist:
     default: true
   - name: bucket4
     foo: baz
+
+# For testing yaml.getSubMap
+nested:
+  inner:
+    foosubst: ${path:conditionalpropermap.[default=true].foo}


### PR DESCRIPTION
This fixes the problem of path based substitutions not working with `YAML.getSubMap(...)`.

With the YAML structure
```
conditionalpropermap:
  bucket3:
    foo: boom
    default: true

nested:
  inner:
    foosubst: ${path:conditionalpropermap.[default=true].foo}
```
this always worked:
```
assertEquals("boom", yaml.get("nested.inner.foosubst"));
```
but
```
assertEquals("boom", yaml.getSubMap("nested").get("inner.foosubst"));

```
did not.


This closes #45 