### PR TITLE
Bugfix: Path substitution still did not work properly with YAML.getSubMap

### DIFF
--- a/src/main/java/dk/kb/util/yaml/YAML.java
+++ b/src/main/java/dk/kb/util/yaml/YAML.java
@@ -212,7 +212,7 @@ public class YAML extends LinkedHashMap<String, Object> {
 
         // Note: getSubstitutors() is used to ensure that substitutors are created for the full YAML.
         //       This is needed for path substitution
-        return new YAML(result, extrapolateSystemProperties, substitutors);
+        return new YAML(result, extrapolateSystemProperties, getSubstitutors());
     }
     
     /**

--- a/src/main/java/dk/kb/util/yaml/YAML.java
+++ b/src/main/java/dk/kb/util/yaml/YAML.java
@@ -209,7 +209,9 @@ public class YAML extends LinkedHashMap<String, Object> {
                     Map.Entry::getValue
             ));
         }
-        
+
+        // Note: getSubstitutors() is used to ensure that substitutors are created for the full YAML.
+        //       This is needed for path substitution
         return new YAML(result, extrapolateSystemProperties, substitutors);
     }
     
@@ -292,7 +294,9 @@ public class YAML extends LinkedHashMap<String, Object> {
             throw new InvalidTypeException(
                     "Exception casting '" + found + "' to List<Map<String, Object>>", path, e);
         }
-        return hmList.stream().map(map -> new YAML(map, extrapolateSystemProperties, substitutors)).collect(Collectors.toList());
+        // Note: getSubstitutors() is used to ensure that substitutors are created for the full YAML.
+        //       This is needed for path substitution
+        return hmList.stream().map(map -> new YAML(map, extrapolateSystemProperties, getSubstitutors())).collect(Collectors.toList());
     }
     
     /**
@@ -671,7 +675,7 @@ public class YAML extends LinkedHashMap<String, Object> {
                                 sub.getClass().getSimpleName(), path);
             }
             try { //Update current as the sub we have found
-                current = new YAML((Map<String, Object>) sub, extrapolateSystemProperties, substitutors);
+                current = new YAML((Map<String, Object>) sub, extrapolateSystemProperties, getSubstitutors());
             } catch (ClassCastException e) {
                 throw new InvalidTypeException(
                         "Expected a Map<String, Object> for path but got ClassCastException", path, e);
@@ -758,7 +762,9 @@ public class YAML extends LinkedHashMap<String, Object> {
             throw new IllegalArgumentException("Conditional index lookup requires sub-elements to be Maps, " +
                     "but the current element was a " + map.getClass().getSimpleName());
         }
-        YAML subYAML = new YAML((Map<String, Object>)map, extrapolateSystemProperties, substitutors);
+        // Note: getSubstitutors() is used to ensure that substitutors are created for the full YAML.
+        //       This is needed for path substitution
+        YAML subYAML = new YAML((Map<String, Object>)map, extrapolateSystemProperties, getSubstitutors());
 
         // Check at the outer level for flat map style
         Object keyValue;
@@ -1186,6 +1192,7 @@ public class YAML extends LinkedHashMap<String, Object> {
      * @return the updated base YAML.
      */
     public static YAML merge(YAML base, YAML extra, MERGE_ACTION defaultMA, MERGE_ACTION listMA) {
+        base.substitutors = null; // Clear existing substitutors. They will be re-created for the merged YAML
         return (YAML)mergeEntry("", base, extra, defaultMA, listMA);
     }
 
@@ -1303,6 +1310,13 @@ public class YAML extends LinkedHashMap<String, Object> {
      * @return s substituted.
      */
     synchronized String substitute(String s) {
+        for (StringSubstitutor substitutor: getSubstitutors()) {
+            s = substitutor.replace(s);
+        }
+        return s;
+    }
+
+    public List<StringSubstitutor> getSubstitutors() {
         if (substitutors == null) {
             substitutors = List.of(
                     // General prefix based
@@ -1312,10 +1326,7 @@ public class YAML extends LinkedHashMap<String, Object> {
                     new StringSubstitutor(StringLookupFactory.INSTANCE.systemPropertyStringLookup()).
                             setEnableUndefinedVariableException(true));
         }
-        for (StringSubstitutor substitutor: substitutors) {
-            s = substitutor.replace(s);
-        }
-        return s;
+        return substitutors;
     }
 
     /**

--- a/src/test/java/dk/kb/util/yaml/YAMLTest.java
+++ b/src/test/java/dk/kb/util/yaml/YAMLTest.java
@@ -596,11 +596,20 @@ class YAMLTest {
     }
 
     @Test
-    public void testSubMapPath() throws IOException {
+    public void testDirectPath() throws IOException {
         YAML yaml = YAML.resolveLayeredConfigs("nested_maps.yml");
         yaml.setExtrapolate(true);
 
         assertEquals("boom", yaml.get("nested.inner.foosubst"), "Getting by full path should work");
+    }
+
+    @Test
+    public void testSubMapPath() throws IOException {
+        YAML yaml = YAML.resolveLayeredConfigs("nested_maps.yml");
+        yaml.setExtrapolate(true);
+
+        // It is important to test this WITHOUT performing the direct get request from testDirectPath first as
+        // that creates the substitutors
         assertEquals("boom", yaml.getSubMap("nested").get("inner.foosubst"), "Getting from submap should work");
     }
 }


### PR DESCRIPTION
Important knowledge: path substitution relies on being able to traverse the **full** YAML file. This presents a problem when a subMap (a subset of the YAML) is extracted as the subMap no longer has access to the full tree.

The previous pull request #46 attempted to solve #45 by copying all `substitutors` (the path substitutor is one of these) when a subMap was extracted, where the `substitutors` has knowledge of the full tree.

The problem was that `substitutors` are lazy created, so if the subMap was requested _before_ any substitution was triggered, the `substitutors` would be null in the subMap and created only on the subMap on first use.

This pull request adds a unit test that triggers the problem as well as a solution by forcing the creation of `substitutors` (if not already created) when a subMap is created. Reversely it also ensures that `substitutors` are reset when merging two YAML structures.