### PR TITLE
Add XMLStepper.serializeSubElements for streaming serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- `XMLStepper.serializeSubElements` for streaming serialization (aka extraction) of XML sub elements.
 
 ## [1.4.14](https://github.com/kb-dk/kb-util/tree/kb-util-1.4.14)
 ### Bugfix

--- a/src/main/resources/xml/InheritNamespace.xml
+++ b/src/main/resources/xml/InheritNamespace.xml
@@ -1,0 +1,20 @@
+<foo xmlns:inner="http://example.com/" xmlns="http://defaultnamespace.example.com/">
+
+    <!-- Inherits both inner & default namespace -->
+    <inner:record>
+        <inner:id>id1</inner:id>
+        <inherited>From default</inherited>
+    </inner:record>
+
+    <!-- Defines alt namespece which is the same as inner -->
+    <alt:record xmlns:alt="http://example.com/">
+        <inner:id>id2</inner:id>
+    </alt:record>
+
+    <!-- Overrides default namespace to be the same as inner -->
+    <record xmlns="http://example.com/newdefault">
+        <inner:id>id3</inner:id>
+        <inherited>From local default</inherited>
+    </record>
+
+</foo>


### PR DESCRIPTION
The added `XMLStepper.serializeSubElements` makes it easy to perform streaming parsing and extraction of sub elements from XML. Usable for things like processing of large OAI-PMH `ListRecords` responses.