### PR TITLE
Misc. Timing improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Extension of the Timing class with several helper methods for lambda and streaming
 
 ## [1.4.14](https://github.com/kb-dk/kb-util/tree/kb-util-1.4.14)
 ### Bugfix

--- a/src/main/java/dk/kb/util/Timing.java
+++ b/src/main/java/dk/kb/util/Timing.java
@@ -35,6 +35,10 @@ public class Timing {
             STATS.name, STATS.subject, STATS.ms, STATS.updates, STATS.ms_updates, STATS.updates_s,
             STATS.min_ms, STATS.max_ms, STATS.utilization
     };
+    public static final STATS[] MS_STATS_SIMPLE = new STATS[]{
+            STATS.name, STATS.subject, STATS.ms, STATS.updates, STATS.ms_updates, STATS.updates_s,
+            STATS.max_ms
+    };
     public static final STATS[] NS_STATS = new STATS[]{
             STATS.name, STATS.subject, STATS.ns, STATS.updates, STATS.ns_updates, STATS.updates_s,
             STATS.min_ns, STATS.max_ns, STATS.utilization
@@ -43,7 +47,7 @@ public class Timing {
     private final String name;
     private final String subject;
     private final String unit;
-    private STATS[] showStats = MS_STATS;
+    private STATS[] showStats;
     private final long objectCreation = System.nanoTime();
 
     private long lastStart = System.nanoTime();
@@ -77,9 +81,7 @@ public class Timing {
      * @param unit    the unit to use for average speed in toString. If null, the unit will be set to {@code upd}.
      */
     public Timing(String name, String subject, String unit) {
-        this.name = name;
-        this.subject = subject;
-        this.unit = unit == null ? "upd" : unit;
+        this(name, subject, unit, MS_STATS);
     }
 
     /**
@@ -171,7 +173,24 @@ public class Timing {
             children.put(name, child);
         }
         return child;
+    }
 
+    /**
+     * Perform 1 call to {@link Runnable#run()}, measuring the time and adding that to the current Timing.
+     * <p>
+     * If the {@code runnable} throws an Exception, the time used up to that Exception is still added, as well as
+     * an increment of {@link #updateCount}.
+     * @param runnable any runnable action.
+     * @return this Timing for further chaining.
+     */
+    public synchronized Timing measure(Runnable runnable) {
+        start();
+        try {
+            runnable.run();
+        } finally {
+            stop();
+        }
+        return this;
     }
 
     /**

--- a/src/main/java/dk/kb/util/Timing.java
+++ b/src/main/java/dk/kb/util/Timing.java
@@ -116,13 +116,22 @@ public class Timing {
         return showStats;
     }
 
-    public void setShowStats(STATS[] showStats) {
+    /**
+     * Specify the stats to show on {@code toString}.
+     * @param showStats the stats to show.
+     * @return this Timing for further chaining.
+     */
+    public Timing setShowStats(STATS[] showStats) {
         this.showStats = showStats == null ? MS_STATS : showStats;
+        return this;
     }
 
     /**
      * If a child with the given name already exists, it will be returned.
      * If a child does not exist, it will be created.
+     * <p>
+     * Note: If the child already exists, {@link #start()} WILL NOT be called automatically.
+     *       Consider chaining with {@code Timing myTiming = parent.getChild(...).start();}
      * @param name child Timing designation. Typically a method name or a similar code-path description.
      * @return the re-used or newly created child.
      */
@@ -133,6 +142,9 @@ public class Timing {
     /**
      * If a child with the given name already exists, it will be returned.
      * If a child does not exist, it will be created.
+     * <p>
+     * Note: If the child already exists, {@link #start()} WILL NOT be called automatically.
+     *       Consider chaining with {@code Timing myTiming = parent.getChild(...).start();}
      * @param name    child Timing designation. Typically a method name or a similar code-path description.
      * @param subject specific child subject. Typically a document ID or similar workload-specific identifier.
      * @return the re-used or newly created child.
@@ -144,6 +156,9 @@ public class Timing {
     /**
      * If a child with the given name already exists, it will be returned.
      * If a child does not exist, it will be created. It will use the default {@link #MS_STATS}.
+     * <p>
+     * Note: If the child already exists, {@link #start()} WILL NOT be called automatically.
+     *       Consider chaining with {@code Timing myTiming = parent.getChild(...).start();}
      * @param name    child Timing designation. Typically a method name or a similar code-path description.
      * @param subject specific child subject. Typically a document ID or similar workload-specific identifier.
      * @param unit    the unit to use for average speed in toString. If null, the unit will be set to {@code upd}.
@@ -156,6 +171,9 @@ public class Timing {
     /**
      * If a child with the given name already exists, it will be returned.
      * If a child does not exist, it will be created.
+     * <p>
+     * Note: If the child already exists, {@link #start()} WILL NOT be called automatically.
+     *       Consider chaining with {@code Timing myTiming = parent.getChild(...).start();}
      * @param name    child Timing designation. Typically a method name or a similar code-path description.
      * @param subject specific child subject. Typically a document ID or similar workload-specific identifier.
      * @param unit    the unit to use for average speed in toString. If null, the unit will be set to {@code upd}.
@@ -177,6 +195,13 @@ public class Timing {
 
     /**
      * Perform 1 call to {@link Runnable#run()}, measuring the time and adding that to the current Timing.
+     * <p>
+     * This is equivalent to
+     * <pre>
+     *     myTiming.start();
+     *     runnable.run();
+     *     myTiming.stop();
+     * </pre>
      * <p>
      * If the {@code runnable} throws an Exception, the time used up to that Exception is still added, as well as
      * an increment of {@link #updateCount}.
@@ -218,13 +243,15 @@ public class Timing {
 
     /**
      * Resets start time to current nanoTime.
-     *
+     * <p>
      * Note: Start is automatically called during construction of this Timing instance.
-     *
+     * <p>
      * Note 2: The use of start() and {@link #stop()} is not thread-safe by nature.
+     * @return this Timing for further chaining.
      */
-    public void start() {
+    public Timing start() {
         lastStart = System.nanoTime();
+        return this;
     }
 
     /**
@@ -349,9 +376,11 @@ public class Timing {
      * Set the update count to the specific number.
      * Note that calling {@link #stop()} auto-increments the updateCount with 1.
      * @param updateCount the number of updated for the timing.
+     * @return this Timing for further chaining.
      */
-    public void setUpdates(int updateCount) {
+    public Timing setUpdates(int updateCount) {
         this.updateCount.set(updateCount);
+        return this;
     }
 
     /**
@@ -388,11 +417,12 @@ public class Timing {
         return count == 0 ? 0 : getNS()/count/1000000;
     }
 
-    public void clear() {
+    public Timing clear() {
         updateCount.set(0);
         lastNS.set(0);
         spendNS.set(0);
         start();
+        return this;
     }
 
     /**

--- a/src/main/java/dk/kb/util/Timing.java
+++ b/src/main/java/dk/kb/util/Timing.java
@@ -132,6 +132,8 @@ public class Timing {
      * <p>
      * Note: If the child already exists, {@link #start()} WILL NOT be called automatically.
      *       Consider chaining with {@code Timing myTiming = parent.getChild(...).start();}
+     * <p>
+     * Note 2: If a child is created it will inherit {@link #showStats} from the parent.
      * @param name child Timing designation. Typically a method name or a similar code-path description.
      * @return the re-used or newly created child.
      */
@@ -145,6 +147,8 @@ public class Timing {
      * <p>
      * Note: If the child already exists, {@link #start()} WILL NOT be called automatically.
      *       Consider chaining with {@code Timing myTiming = parent.getChild(...).start();}
+     * <p>
+     * Note 2: If a child is created it will inherit {@link #showStats} from the parent.
      * @param name    child Timing designation. Typically a method name or a similar code-path description.
      * @param subject specific child subject. Typically a document ID or similar workload-specific identifier.
      * @return the re-used or newly created child.
@@ -159,6 +163,8 @@ public class Timing {
      * <p>
      * Note: If the child already exists, {@link #start()} WILL NOT be called automatically.
      *       Consider chaining with {@code Timing myTiming = parent.getChild(...).start();}
+     * <p>
+     * Note 2: If a child is created it will inherit {@link #showStats} from the parent.
      * @param name    child Timing designation. Typically a method name or a similar code-path description.
      * @param subject specific child subject. Typically a document ID or similar workload-specific identifier.
      * @param unit    the unit to use for average speed in toString. If null, the unit will be set to {@code upd}.
@@ -183,11 +189,11 @@ public class Timing {
     @SuppressWarnings("SameParameterValue")
     public synchronized Timing getChild(String name, String subject, String unit, STATS[] showStats) {
         if (children == null) {
-            children = new LinkedHashMap<String, Timing>();
+            children = new LinkedHashMap<>();
         }
         Timing child = children.get(name);
         if (child == null) {
-            child = new Timing(name, subject, unit, showStats);
+            child = new Timing(name, subject, unit, showStats == null ? this.showStats : showStats);
             children.put(name, child);
         }
         return child;

--- a/src/test/java/dk/kb/util/TimingTest.java
+++ b/src/test/java/dk/kb/util/TimingTest.java
@@ -24,6 +24,8 @@ package dk.kb.util;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.concurrent.atomic.AtomicLong;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 public class TimingTest {
@@ -86,5 +88,17 @@ public class TimingTest {
             assertFalse(child.toString().contains("util"),
                     "Simple stats for child should not contain utilization, even when parent showStat has changed");
         }
+    }
+
+    @Test
+    public void testMeasureRunnable() {
+        AtomicLong receiver = new AtomicLong();
+        new Timing("parent").measure(() -> receiver.set(87L));
+        assertEquals(87L, receiver.get());
+    }
+
+    @Test
+    public void testMeasureSupplier() {
+        assertEquals(87L, new Timing("parent").measure(() -> 87L));
     }
 }

--- a/src/test/java/dk/kb/util/TimingTest.java
+++ b/src/test/java/dk/kb/util/TimingTest.java
@@ -22,8 +22,9 @@
  */
 package dk.kb.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 public class TimingTest {
 
@@ -40,6 +41,7 @@ public class TimingTest {
                    "Timing info should be >= sleep time (50*1000000ns) but was " + ns);
     }
 
+    @Test
     public void testSub() throws InterruptedException {
         Timing timing = new Timing("foo");
         Thread.sleep(50);
@@ -55,5 +57,34 @@ public class TimingTest {
 
         Thread.sleep(10);
         System.out.println("Final output: " + timing);
+    }
+
+    @Test
+    public void testStats() {
+        Timing parent = new Timing("parent").setShowStats(Timing.MS_STATS_SIMPLE);
+        parent.measure(() -> {
+            if (System.currentTimeMillis() == 0) {
+                throw new RuntimeException("Impossible time");
+            }
+        });
+        Timing child = parent.getChild("child").measure(() -> {
+            if (System.currentTimeMillis() == 0) {
+                throw new RuntimeException("Impossible time");
+            }
+        });
+
+        {
+            assertFalse(parent.toString().contains("util"),
+                    "Simple stats for parent should not contain utilization");
+        }
+        {
+            parent.setShowStats(Timing.MS_STATS);
+            assertTrue(parent.toString().contains("util"),
+                    "Full stats should contain utilization after shange to showStats");
+        }
+        {
+            assertFalse(child.toString().contains("util"),
+                    "Simple stats for child should not contain utilization, even when parent showStat has changed");
+        }
     }
 }


### PR DESCRIPTION
The `Timing` class is to be used in multiple places in the DS services. This pull request fixes a problem where the output template could not be adjusted in some situations and adds several convenience methods for measuring streaming processing steps.