### PR TITLE
Make HttpServletResponse optional in ExportWriterFactory.wrap

### DIFF
--- a/src/main/java/dk/kb/util/webservice/stream/ExportWriterFactory.java
+++ b/src/main/java/dk/kb/util/webservice/stream/ExportWriterFactory.java
@@ -103,7 +103,7 @@ public class ExportWriterFactory {
      }
      * </pre>
      * @param output      the destination stream.
-     * @param response    used for setting the proper contentType.
+     * @param response    used for setting the proper contentType. Can be null.
      * @param format      the format to export to.
      * @param writeNulls  if true, null-values are exported as {@code "key":null} for JSON and JSONL.
      *                    If false, null-values are not stated.
@@ -115,7 +115,11 @@ public class ExportWriterFactory {
      */
     public static ExportWriter wrap(OutputStream output, HttpServletResponse response,
                                     FORMAT format, boolean writeNulls, String rootElement) {
-        format.setContentType(response);
+        if (response == null) {
+            log.warn("warp: No HttpServletResponse given so the content MIME type could not be set");
+        } else {
+            format.setContentType(response);
+        }
         Writer writer = new OutputStreamWriter(output, StandardCharsets.UTF_8);
         switch (format) {
             case jsonl: return new JSONStreamWriter(writer, JSONStreamWriter.FORMAT.jsonl, writeNulls);


### PR DESCRIPTION
Requiring a `HttpServletResponse` parameter for wrapping an `OutputStream` in an `ExportWriter` is not a clean separation of responsibilities. Unfortunately there is no real clean way. As a patch for the requirement, this pull request allows it to be `null`.

This mirrors the functionality in the corresponding `ExportWriterFactory` in [ds-resent](https://github.com/kb-dk/ds-present/) which can then be removed from `ds-present`. The kb.dk internal issue is DISC-40.