### PR TITLE
Extended HTTP header support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Support for request headers when creating HeaderInputStreams from URIs
+- Support for Paging-Record-Count headers for continuations
 
 ## [1.4.18](https://github.com/kb-dk/kb-util/tree/kb-util-1.4.18)
 ### Added

--- a/src/main/java/dk/kb/util/webservice/stream/ContinuationInputStream.java
+++ b/src/main/java/dk/kb/util/webservice/stream/ContinuationInputStream.java
@@ -51,7 +51,22 @@ public class ContinuationInputStream<C> extends HeaderInputStream implements Aut
      * @throws IOException if the connection failed.
      */
     public static <C2> ContinuationInputStream<C2> from(URI uri, Function<String, C2> tokenMapper) throws IOException {
-        HttpURLConnection con = getHttpURLConnection(uri);
+        return from(uri, tokenMapper, null);
+    }
+
+    /**
+     * Establish a connection to the given {@code uri}, extract all headers and construct a
+     * {@link ContinuationInputStream} with the headers and response stream from the {@code uri}.
+     * @param uri full URI for a call to a webservice.
+     * @param tokenMapper maps the String header {@link ContinuationUtil#HEADER_PAGING_CONTINUATION_TOKEN}
+     *                    to the concrete token type.
+     * @param requestHeaders optional headers for the connection. Can be null.
+     * @return an {@code InputStream} with the response.
+     * @throws IOException if the connection failed.
+     */
+    public static <C2> ContinuationInputStream<C2> from(
+            URI uri, Function<String, C2> tokenMapper, Map<String, String> requestHeaders) throws IOException {
+        HttpURLConnection con = getHttpURLConnection(uri, requestHeaders);
         Map<String, List<String>> headers = con.getHeaderFields();
         C2 continuationToken = ContinuationUtil.getContinuationToken(headers, tokenMapper).orElse(null);
         Boolean hasMore = ContinuationUtil.getHasMore(headers).orElse(null);

--- a/src/main/java/dk/kb/util/webservice/stream/ContinuationUtil.java
+++ b/src/main/java/dk/kb/util/webservice/stream/ContinuationUtil.java
@@ -43,7 +43,7 @@ public class ContinuationUtil {
     public static final String HEADER_PAGING_HAS_MORE = "Paging-Has-More";
     
     /**
-     * Set as HTTP header by record streaming endpoints to communicate the number of re cords in the current stream.
+     * Set as HTTP header by record streaming endpoints to communicate the number of records in the current stream.
      */
     public static final String HEADER_PAGING_RECORD_COUNT = "Paging-Record-Count";
 

--- a/src/main/java/dk/kb/util/webservice/stream/HeaderInputStream.java
+++ b/src/main/java/dk/kb/util/webservice/stream/HeaderInputStream.java
@@ -69,10 +69,14 @@ public class HeaderInputStream extends FilterInputStream implements AutoCloseabl
      * @return a connection to the given {@code uri}.
      * @throws IOException if the connection response was not {@code >= 200} and {@code <= 299}.
      */
-    protected static HttpURLConnection getHttpURLConnection(URI uri) throws IOException {
-        log.debug("Opening streaming connection to '{}'", uri);
+    protected static HttpURLConnection getHttpURLConnection(
+            URI uri, Map<String, String> requestHeaders) throws IOException {
+        log.debug("Opening streaming connection to '{}' with headers {}", uri, requestHeaders);
         HttpURLConnection con = (HttpURLConnection) uri.toURL().openConnection();
         con.setInstanceFollowRedirects(true);
+        if (requestHeaders != null) {
+            requestHeaders.forEach(con::setRequestProperty);
+        }
         int status = con.getResponseCode();
         if (status < 200 || status > 299) {
             throw new IOException("Got HTTP " + status + " establishing connection to '" + uri + "'");

--- a/src/main/java/dk/kb/util/webservice/stream/HeaderInputStream.java
+++ b/src/main/java/dk/kb/util/webservice/stream/HeaderInputStream.java
@@ -97,6 +97,18 @@ public class HeaderInputStream extends FilterInputStream implements AutoCloseabl
     }
 
     /**
+     * Extract the header values for the given key from the response headers.
+     * In case of no values, the empty list is returned.
+     * @param key HTTP response header key.
+     * @return the HTTP response header values for the given {@code key}.
+     */
+    public List<String> getResponseHeaders(String key) {
+        return headers == null || !headers.containsKey(key) || headers.get(key).isEmpty() ?
+                Collections.emptyList() :
+                headers.get(key);
+    }
+
+    /**
      * Establish a connection to the given {@code uri}, throwing an exception if the response is not {@code >= 200}
      * and {@code <= 299}.
      * @param uri the URI to establish a connection to.

--- a/src/main/java/dk/kb/util/webservice/stream/HeaderStream.java
+++ b/src/main/java/dk/kb/util/webservice/stream/HeaderStream.java
@@ -33,9 +33,11 @@ public class HeaderStream<T> extends FilterStream<T> implements AutoCloseable {
     protected final Map<String, List<String>> responseHeaders;
 
     /**
-     * Create a stream.
+     * Take the {@code inner} stream and wrap it, without setting headers.
+     * Except for the class, this is effectively the same as the non-wrapped {@code inner}.
      *
-     * @param inner   the provider of the elements.
+     * @param inner the stream to wrap as a {@code HeaderStream}.
+     * @see #HeaderStream(Stream, Map)
      */
     public HeaderStream(Stream<T> inner) {
         super(inner);
@@ -44,9 +46,10 @@ public class HeaderStream<T> extends FilterStream<T> implements AutoCloseable {
     }
 
     /**
-     * Create a stream.
+     * Take the {@code inner} stream and wrap it along with the provided {@code responseHeaders}.
+     * All stream functionality for {@code inner} is unchanged.
      *
-     * @param inner           the provider of the elements.
+     * @param inner           the stream to wrap as a {@code HeaderStream}.
      * @param responseHeaders HTTP headers from the response that {@code inner} was constructed from.
      */
     public HeaderStream(Stream<T> inner, Map<String, List<String>> responseHeaders) {

--- a/src/main/java/dk/kb/util/webservice/stream/HeaderStream.java
+++ b/src/main/java/dk/kb/util/webservice/stream/HeaderStream.java
@@ -1,0 +1,76 @@
+/*
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package dk.kb.util.webservice.stream;
+
+import dk.kb.util.FilterStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * HTTP specific {@link Stream} wrapper that keeps track of the headers returned by the server.
+ * @param <T> the class of objects for the stream.
+ */
+public class HeaderStream<T> extends FilterStream<T> implements AutoCloseable {
+    private static final Logger log = LoggerFactory.getLogger(HeaderStream.class);
+
+    protected final Map<String, List<String>> responseHeaders;
+
+    /**
+     * Create a stream.
+     *
+     * @param inner   the provider of the elements.
+     */
+    public HeaderStream(Stream<T> inner) {
+        super(inner);
+        this.responseHeaders = null;
+        log.debug("Creating HeaderStream without headers");
+    }
+
+    /**
+     * Create a stream.
+     *
+     * @param inner           the provider of the elements.
+     * @param responseHeaders HTTP headers from the response that {@code inner} was constructed from.
+     */
+    public HeaderStream(Stream<T> inner, Map<String, List<String>> responseHeaders) {
+        super(inner);
+        this.responseHeaders = responseHeaders;
+        log.debug("Creating HeaderStream with headers {}", responseHeaders);
+    }
+
+    /**
+     * @return the HTTP headers from the response that this stream was constructed from. Can be null.
+     */
+    public Map<String, List<String>> getResponseHeaders() {
+        return responseHeaders;
+    }
+
+    /**
+     * Extract the header with the given key from the response headers.
+     * In case of multiple values, only the first one is returned.
+     * In case of no values, {@code null} is returned.
+     * @param key HTTP response header key.
+     * @return First HTTP response header value for the given {@code key} or null is there are no values.
+     */
+    public String getResponseHeader(String key) {
+        return responseHeaders == null || !responseHeaders.containsKey(key) || responseHeaders.get(key).isEmpty() ?
+                null :
+                responseHeaders.get(key).get(0);
+    }
+}

--- a/src/main/java/dk/kb/util/webservice/stream/HeaderStream.java
+++ b/src/main/java/dk/kb/util/webservice/stream/HeaderStream.java
@@ -18,6 +18,7 @@ import dk.kb.util.FilterStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -73,4 +74,18 @@ public class HeaderStream<T> extends FilterStream<T> implements AutoCloseable {
                 null :
                 responseHeaders.get(key).get(0);
     }
+
+    /**
+     * Extract the header values for the given key from the response headers.
+     * In case of no values, the empty list is returned.
+     * @param key HTTP response header key.
+     * @return the HTTP response header values for the given {@code key}.
+     */
+    public List<String> getResponseHeaders(String key) {
+        return responseHeaders == null || !responseHeaders.containsKey(key) || responseHeaders.get(key).isEmpty() ?
+                Collections.emptyList() :
+                responseHeaders.get(key);
+    }
+
+
 }

--- a/src/test/java/dk/kb/util/webservice/stream/ContinuationStreamTest.java
+++ b/src/test/java/dk/kb/util/webservice/stream/ContinuationStreamTest.java
@@ -34,7 +34,7 @@ class ContinuationStreamTest {
         try (ContinuationInputStream<Long> is =
                      new ContinuationInputStream<>(
                              new ByteArrayInputStream(JSONStreamUtilTest.RECORDS2.getBytes(StandardCharsets.UTF_8)),
-                             124L, true) ;
+                             124L, true, 2L) ;
              ContinuationStream<DsRecordDto, Long> recordStream = is.stream(DsRecordDto.class)) {
             List<DsRecordDto> records = recordStream.collect(Collectors.toList());
             assertEquals(2, records.size(), "There should be the right number of records");
@@ -42,6 +42,7 @@ class ContinuationStreamTest {
             assertEquals(is.getContinuationToken(), records.get(records.size()-1).getmTime(),
                     "The continuation token should match the last record");
             assertEquals(true, is.hasMore(), "The has more flag should be transfered");
+            assertEquals(records.size(), is.getRecordCount(), "Record count should match");
         }
     }
 
@@ -50,12 +51,13 @@ class ContinuationStreamTest {
         try (ContinuationInputStream<Long> is =
                      new ContinuationInputStream<>(
                              new ByteArrayInputStream(JSONStreamUtilTest.RECORDS0.getBytes(StandardCharsets.UTF_8)),
-                             null, false) ;
+                             null, false, 0L) ;
              ContinuationStream<DsRecordDto, Long> recordStream = is.stream(DsRecordDto.class)) {
             List<DsRecordDto> records = recordStream.collect(Collectors.toList());
             assertTrue(records.isEmpty(), "There should be no records");
             assertNull(is.getContinuationToken(), "There should be no continuation token");
             assertEquals(false, is.hasMore(), "The has more flag should be transfered");
+            assertEquals(0, is.getRecordCount(), "Record count should be 0");
         }
     }
 

--- a/src/test/java/dk/kb/util/webservice/stream/HeaderInputStreamTest.java
+++ b/src/test/java/dk/kb/util/webservice/stream/HeaderInputStreamTest.java
@@ -35,7 +35,7 @@ class HeaderInputStreamTest {
         String headerString;
         try (HeaderInputStream headerStream = HeaderInputStream.from(uri)) {
             headerString = IOUtils.toString(headerStream, StandardCharsets.UTF_8);
-            assertEquals("bytes", headerStream.getHeaders().get("Accept-Ranges").get(0),
+            assertEquals("bytes", headerStream.getResponseHeaders().get("Accept-Ranges").get(0),
                     "The header 'Accept-Ranges: bytes' should be present");
         }
 


### PR DESCRIPTION
This pull request adds more support for HTTP headers, ultimately needed for OAuth2 token propagation.

* Optional request headers when creating a `HeaderInputStream` from an URL
* Full header transfer with `ContinuationStream` via new super class `HeaderStream`
* New continuation header `Paging-Record-Count` for signalling the logical size of the serialized batch
