### PR TITLE
Up front extrapolation/substitution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fully generic `getMultiple` method, utilizing the Visitor implementation 
 
 ### Changed
-- Leaf-key based `getMultiple` and `getMultipleFromSubYaml` in `YAML` are now deprecated as the extended YAML syntax cover these scenarios
-- YAML substitution now enabled per default and is done upon load
-
+- Leaf-key based `getMultipleFromSubYaml` in `YAML` is now deprecated as the extended YAML syntax cover these scenarios
+- Breaking: Leaf-key based `getMultiple` has changed behaviour to generic yPath expansion  
 
 ## [1.4.26](https://github.com/kb-dk/kb-util/tree/kb-util-1.4.26)
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Extended YAML-path syntax: `**` for matching any key at any depth 
+- YAML-path supporting [Visitor](https://en.wikipedia.org/wiki/Visitor_pattern) pattern for YAML
+- Fully generic `getMultiple` method, utilizing the Visitor implementation 
+
+### Changed
+- Leaf-key based `getMultiple` and `getMultipleFromSubYaml` in `YAML` are now deprecated as the extended YAML syntax cover these scenarios
+- YAML substitution now enabled per default and is done upon load
 
 
 ## [1.4.26](https://github.com/kb-dk/kb-util/tree/kb-util-1.4.26)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Leaf-key based `getMultipleFromSubYaml` in `YAML` is now deprecated as the extended YAML syntax cover these scenarios
-- Breaking: Leaf-key based `getMultiple` has changed behaviour to generic yPath expansion  
+- Breaking: Leaf-key based `getMultiple` has changed behaviour to generic yPath expansion
+- Breaking: Default behaviour for YAML is now to extrapolate. Alternate constructors are provided to disable extrapolation
 
 ## [1.4.26](https://github.com/kb-dk/kb-util/tree/kb-util-1.4.26)
 ### Added

--- a/src/main/java/dk/kb/util/yaml/YAML.java
+++ b/src/main/java/dk/kb/util/yaml/YAML.java
@@ -174,7 +174,7 @@ public class YAML extends LinkedHashMap<String, Object> {
      * <p>
      * Note: Dots {@code .} in YAML keys can be escaped with quotes: {@code foo.'a.b.c' -> [foo, a.b.c]}.
      * <p>
-     * This method is equal to {@link #getSubMap(String)}. {@code getYAML} is preferred dut to clearer semantics.
+     * This method is equal to {@link #getSubMap(String)}. {@code getYAML} is preferred due to clearer semantics.
      * @param path path for the sub map.
      * @return the map at the path
      * @throws NotFoundException    if the path could not be found
@@ -616,25 +616,6 @@ public class YAML extends LinkedHashMap<String, Object> {
             return defaultValue;
         }
     }
-
-    // TODO: Evaluate the redefinition of getMultiple
-    // The old getMultiple 
-
-//    /**
-//     * Resolves all values related to a given key, from a YAML structure. All values that have the specified key are
-//     * returned as part of a list.
-//     * @deprecated
-//     * This is no longer the best method to visit values. Use {@link #visit(Object, YAML, YAMLVisitor)} instead.
-//     * @param key the key to look for in the input YAML.
-//     * @return a list of all values that can be cast to strings.
-//     */
-//    @Deprecated
-//    public List<Object> getMultiple(String key){
-//        String correctedPath = "**." + key;
-//        MultipleValuesVisitor visitor = new MultipleValuesVisitor();
-//        visit(correctedPath, this, visitor);
-//        return visitor.extractedValues;
-//    }
 
     /**
      * Resolves all values related to a given key, from a part of a YAML structure. All values that are children of the

--- a/src/main/java/dk/kb/util/yaml/YPath.java
+++ b/src/main/java/dk/kb/util/yaml/YPath.java
@@ -144,4 +144,9 @@ public class YPath {
     public int size() {
         return yPath.size();
     }
+
+    @Override
+    public String toString() {
+        return "YPath(" + yPath + ')';
+    }
 }

--- a/src/test/java/dk/kb/util/yaml/YAMLTest.java
+++ b/src/test/java/dk/kb/util/yaml/YAMLTest.java
@@ -956,4 +956,16 @@ class YAMLTest {
                 "Enabling extrapolation with a failing substitution should fail with an exception");
     }
 
+    // List<YAML> yamls1 = getYAMLList("foo")
+    // and
+    // List<YAML> yamls1 = getList("foo")
+    // should both work
+    @Test
+    public void testGetImplicitYAMLList() throws IOException {
+        YAML yaml = YAML.resolveLayeredConfigs("yaml/visitor.yaml");
+        List<YAML> explicit = yaml.getYAMLList("test.tuplesequence");
+        List<YAML> implicit = yaml.getList("test.tuplesequence");
+        assertEquals(explicit.toString(), implicit.toString(),
+                "Explicit and implicit List<YAML> retrieval should be the same");
+    }
 }

--- a/src/test/java/dk/kb/util/yaml/YAMLTest.java
+++ b/src/test/java/dk/kb/util/yaml/YAMLTest.java
@@ -557,7 +557,7 @@ class YAMLTest {
     @Test
     public void testReverseConditionalIndex() throws IOException {
         YAML yaml = YAML.resolveLayeredConfigs("nested_maps.yml");
-        assertEquals("bar", yaml.get("conditionalpropermap.[default!=true].foo"));
+        assertEquals("[bar, zoo, baz]", yaml.getMultiple("conditionalpropermap.[default!=true].foo").toString());
     }
 
     @Test
@@ -746,7 +746,7 @@ class YAMLTest {
     @Test
     public void testDoubleWildcardLast() throws IOException {
         YAML yaml = YAML.resolveLayeredConfigs("yaml/visitor.yaml");
-        assertEquals(1, yaml.get("test.anotherlevel.name.**"),
+        assertEquals("[1, 2, 3, john]", yaml.getMultiple("test.anotherlevel.name.**").toString(),
                 "Double wildcard at the end of the path");
     }
 
@@ -823,7 +823,8 @@ class YAMLTest {
                 "Path substitution should work for visit using conditionals");
     }
 
-    @Test
+    // Disabled 20240312 due to change of the behaviour of getMultiple
+    @Disabled
     public void testGetMultipleOld() throws IOException {
         YAML yaml = YAML.resolveLayeredConfigs("yaml/visitor.yaml");
         List<String> testValues = Arrays.asList("fooz", "foo", "bar", "baz", "qux", "john", "doe",
@@ -833,7 +834,8 @@ class YAMLTest {
         assertEquals(16, extractedNames.size());
     }
 
-    @Test
+    // Disabled 20240312 due to change of the behaviour of getMultiple
+    @Disabled
     public void testSubsetFromGetMultipleOld() throws IOException {
         YAML yaml = YAML.resolveLayeredConfigs("yaml/visitor.yaml");
         List<YAML> subsetYaml = yaml.getYAMLList("test.tuplesequence");

--- a/src/test/java/dk/kb/util/yaml/YAMLTest.java
+++ b/src/test/java/dk/kb/util/yaml/YAMLTest.java
@@ -863,12 +863,18 @@ class YAMLTest {
         assertTrue(extractedNames.containsAll(testValues));
     }
 
-    // Switching to up front extrapolating in 20240311
     @Test
-    public void testExtrapolatingDefaultNotEnabled() throws IOException {
+    public void testExtrapolatingDefaultEnabled() throws IOException {
         YAML yaml = YAML.resolveLayeredConfigs("yaml/extrapolation.yaml");
+        assertEquals("foo", yaml.getString("test.somestring"),
+                "Default should be extrapolation for test.somestring");
+    }
+
+    @Test
+    public void testDisableInterpolation() throws IOException {
+        YAML yaml = YAML.resolveLayeredConfigs(false, "yaml/extrapolation.yaml");
         assertEquals("${path:ypath.major}", yaml.getString("test.somestring"),
-                "Default should be no extrapolation for test.somestring");
+                "Disabling interpolation should work for test.somestring");
     }
 
     @Test
@@ -951,7 +957,7 @@ class YAMLTest {
 
     @Test
     public void testExtrapolatingFail() throws IOException {
-        YAML yaml = YAML.resolveLayeredConfigs("yaml/extrapolation_fail.yaml");
+        YAML yaml = YAML.resolveLayeredConfigs(false, "yaml/extrapolation_fail.yaml");
         assertThrowsExactly(IllegalArgumentException.class, () -> yaml.setExtrapolate(true),
                 "Enabling extrapolation with a failing substitution should fail with an exception");
     }

--- a/src/test/resources/testExtrapolated.yml
+++ b/src/test/resources/testExtrapolated.yml
@@ -4,8 +4,9 @@ test:
   someint: ${java.specification.version}
   somedouble: ${java.class.version}
   somebool: true
-  exceptionimplicit: ${nonexisting.property}
-  exceptionenv: ${env:NOT_HERE}
+  # Removed 20240312 as extrapolation has changed to being up front instead of request time
+#  exceptionimplicit: ${nonexisting.property}
+#  exceptionenv: ${env:NOT_HERE}
   fallback: ${nonexisting.property:-mydefault}
   envfallback: ${sys:NOT_DEFINED:-envdefault}
   nestedfallback: ${nonexisting:-${user.home:-dontreach}}

--- a/src/test/resources/yaml/extrapolation.yaml
+++ b/src/test/resources/yaml/extrapolation.yaml
@@ -1,0 +1,52 @@
+# Test YAML
+test:
+  somestring: ${path:ypath.major}
+  someint: ${path:ypath.wholenumber}
+#  nothere: ${path:ypath.noexistingpath}
+  somedouble: ${path:ypath.doubleval}
+  somebool: ${path:ypath.boolval}
+#  somenull: ${path:ypath.nullval}
+
+  indirectstart: ${path:test.indirectmiddle}
+  indirectmiddle: ${path:test.indirectend}
+  indirectend: ${user.name}
+
+  indirectstringlist:
+    - ${path:ypath.major}
+    - ${path:ypath.minor}
+
+  indirectnumberlist:
+    - ${path:ypath.wholenumber}
+    - ${path:ypath.wholenumbertwo}
+
+  # Substitution currently only works for values that can be represented as simple strings
+  # TODO: Expand substitution to handle paths to structures
+  emptylist: ${path:ypath.emptylistval}
+
+  indirectnumbermap:
+    foo: ${path:ypath.wholenumber}
+    bar: ${path:ypath.wholenumbertwo}
+    sub:
+      subfoo: ${path:ypath.wholenumber}
+
+ypath:
+  major: foo
+  minor: oof
+  wholenumber: 123
+  wholenumbertwo: 234
+  doubleval: 12.34
+  boolval: true
+  nullval: null
+  emptylistval: []
+
+  sublist:
+    - ${path:ypath.major}
+  sublist2:
+    - submap:
+        ref: ${path:ypath.major}
+  direct: ${path:ypath.major}
+  maps:
+    - order: first
+      value: ${path:ypath.major}
+    - order: second
+      value: bar

--- a/src/test/resources/yaml/extrapolation_fail.yaml
+++ b/src/test/resources/yaml/extrapolation_fail.yaml
@@ -1,0 +1,3 @@
+# Test YAML
+test:
+  nothere: ${path:ypath.noexistingpath}

--- a/src/test/resources/yaml/null.yaml
+++ b/src/test/resources/yaml/null.yaml
@@ -1,0 +1,11 @@
+# Different representations of null (keyword null, tilde ~ and empty value)
+nullvalue: null
+tildevalue: ~
+emptyvalue:
+defaultnull: ${nonexisting.property:null}
+nulllist:
+  - foo
+  - null
+  - ~
+  -
+  - bar


### PR DESCRIPTION
Extrapolation/substitution in `kb-util`'s `YAML` expands system properties, arguments and YAML-paths. The previous implementation performed substitution at request time, which made it difficult to implement things like the [Visitor Pattern](https://en.wikipedia.org/wiki/Visitor_pattern) extraction of sub-structures without introducing errors.

The primary implementation in this pull request is to perform a full extrapolation/substitution across the whole YAML when `setExtrapolate(true)` is called. 

Secondary fixes are
* Cleanup of Javadoc by moving `yPath` description to the class javadoc
* Changed behaviour of `getMultiple(String)` to treat the input af an `yPath` to mirror `get`. This is a breaking change, which has been discussed with @jorntx. The break was deemed acceptable as the old `getMultiple(String)` has only been part of `YAML` for a month
* `List<YAML> sub = myyaml.getList<YAML>(yPath)` now works. Previously it was necessary to call an explicit method to get a list of YAMLS: `List<YAML> sub = myyaml.getYAMLList(yPath)`
* If `get(yPath)` finds more than 1 value, an exception is thrown. The logic is that `get` is singular and multiple matches are nearly always a sign of something gone wrong. If the caller really want to use the first value from an `yPath` and is fine with ignoring subsequent values, `getMultiple(yPath)` can be used
* Extrapolation now supports indirect resolving, e.g. calling `get("foo")` for the structure below will return the user name
```yaml
foo: ${path:bar}
bar:${path:boom}
boom: ${user.name}
```

Discussion point
* The extrapolation is not done automatically. This is the same behaviour as before, but might not be the best. Should it be enabled per default?