### PR TITLE
Bugfix `Timing.toString`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Timing.toString now allows child-specific display elements instead of using the parent elements
 
 ## [1.5.0](https://github.com/kb-dk/kb-util/tree/kb-util-1.5.0)
 ### Added

--- a/src/main/java/dk/kb/util/Timing.java
+++ b/src/main/java/dk/kb/util/Timing.java
@@ -206,7 +206,7 @@ public class Timing {
     /**
      * Perform 1 call to {@link Runnable#run()}, measuring the time and adding that to the current Timing.
      * <p>
-     * This is equivalent to
+     * This is a thread-safe equivalent of
      * <pre>
      *     myTiming.start();
      *     runnable.run();
@@ -239,7 +239,7 @@ public class Timing {
      * Perform 1 call to {@link Supplier#get()}, measuring the time and adding that to the current Timing before
      * returning the result of the call. The supplier will be called exactly once.
      * <p>
-     * This is equivalent to
+     * This is a thread-safe equivalent of
      * <pre>
      *     myTiming.start();
      *     myResult = supplier.get();

--- a/src/main/java/dk/kb/util/Timing.java
+++ b/src/main/java/dk/kb/util/Timing.java
@@ -546,7 +546,7 @@ public class Timing {
      * @return recursive timing information using the existing {@link #showStats} setup.
      */
     public String toString() {
-        return toString(showStats, false);
+        return toString((STATS[])null, false);
     }
 
     /**
@@ -560,7 +560,9 @@ public class Timing {
     }
 
     /**
-     * @param ns if true, nano-seconds are returned, else milli-seconds.
+     * String serialization using fixed stat elements.
+     * @param ns if true, stats with nano-seconds are returned using {@link #NS_STATS},
+     *          else milli-seconds are returned using {@link #MS_STATS}.
      * @param indent if true, the result is rendered multi-line and indented.
      * @return recursive timing information in nano- or milli-seconds.
      */
@@ -568,15 +570,31 @@ public class Timing {
         return toString(ns ? NS_STATS : MS_STATS, indent);
     }
 
+    /**
+     * String serialization using fixed stat elements.
+     * @param sb will receive the serialized stats.
+     * @param ns if true, stats with nano-seconds are returned using {@link #NS_STATS},
+     *          else milli-seconds are returned using {@link #MS_STATS}.
+     */
     public void toString(StringBuilder sb, boolean ns) {
         toString(sb, ns, false);
     }
 
+    /**
+     * String serialization using fixed stat elements.
+     * @param sb will receive the serialized stats.
+     * @param ns if true, stats with nano-seconds are returned using {@link #NS_STATS},
+     *          else milli-seconds are returned using {@link #MS_STATS}.
+     * @param indent if true, the result is rendered multi-line and indented.
+     */
     synchronized void toString(StringBuilder sb, boolean ns, boolean indent) {
         toString(sb, ns ? NS_STATS : MS_STATS, indent, "");
     }
 
     /**
+     * String serialization using explictly stated {@link STATS}. Note that {@code showStats} will be used transitively
+     * for all {@code Timing} elements in the tree. State {@code null} to serialize using the {@link STATS} already
+     * defined for each element.
      * @param showStats the stats to output. Pre-defined collections are {@link #MS_STATS} and {@link #NS_STATS}.
      * @return recursive timing information.
      */
@@ -585,6 +603,9 @@ public class Timing {
     }
 
     /**
+     * String serialization using explictly stated {@link STATS}. Note that {@code showStats} will be used transitively
+     * for all {@code Timing} elements in the tree. State {@code null} to serialize using the {@link STATS} already
+     * defined for each element.
      * @param showStats the stats to output. Pre-defined collections are {@link #MS_STATS} and {@link #NS_STATS}.
      * @param indent if true, the result is rendered multi-line and indented.
      * @return recursive timing information.
@@ -597,7 +618,8 @@ public class Timing {
 
     private synchronized void toString(StringBuilder sb, STATS[] showStats, boolean indent, String spaces) {
         sb.append(spaces);
-        for (STATS stat: showStats) {
+        final STATS[] localStats = showStats == null ? this.showStats : showStats;
+        for (STATS stat: localStats) {
             if (stat == STATS.name) {
                 sb.append(name);
                 break;
@@ -605,7 +627,7 @@ public class Timing {
         }
         sb.append("(");
         boolean empty = true;
-        for (STATS stat: showStats) {
+        for (STATS stat: localStats) {
             if (stat == STATS.name || (stat == STATS.subject && subject == null)) {
                 continue;
             }
@@ -668,7 +690,6 @@ public class Timing {
                     first = false;
                 } else {
                     sb.append(indent ? ",\n" : ", ");
-                    first = false;
                 }
                 child.toString(sb, showStats, indent, indent ? spaces + "  " : "");
             }

--- a/src/test/java/dk/kb/util/TimingTest.java
+++ b/src/test/java/dk/kb/util/TimingTest.java
@@ -89,7 +89,7 @@ public class TimingTest {
         {
             parent.setShowStats(Timing.MS_STATS);
             assertTrue(parent.toString().contains("util"),
-                    "Full stats should contain utilization after shange to showStats");
+                    "Full stats should contain utilization after change to showStats");
         }
         {
             assertFalse(child.toString().contains("util"),
@@ -99,6 +99,26 @@ public class TimingTest {
         Function<Integer, Integer> measuredF = num -> parent.measure(() -> myFunction.apply(num));
 
         Stream.of(1, 2, 3).map(measuredF).collect(Collectors.toList());
+    }
+
+    @Test
+    public void testTransitive() {
+        Timing parent = new Timing("parent").setShowStats(Timing.MS_STATS_SIMPLE);
+        parent.measure(() -> {
+            if (System.currentTimeMillis() == 0) {
+                throw new RuntimeException("Impossible time");
+            }
+        });
+        assertFalse(parent.toString().contains("util"), "parent should not contain utilization without child");
+        Timing child = parent.getChild("child").measure(() -> {
+            if (System.currentTimeMillis() == 0) {
+                throw new RuntimeException("Impossible time");
+            }
+        });
+        child.setShowStats(Timing.MS_STATS);
+
+        assertTrue(child.toString().contains("util"), "child should contain utilization");
+        assertTrue(parent.toString().contains("util"), "parent.toString should contain utilization due to child");
     }
 
     @Test


### PR DESCRIPTION
When calling `Timing.toString`, the setup for the concrete `Timing` instance determines what to print. However, when calling it on a parent `Timing` with children, all children inherit the parent's setup, instead of using their own.

This pull request fixed the problem by allowing the `toString` argument `showStats=null`, signalling that the previously setup should be used for printing.