### PR TITLE
Add option to CallbackReplacer for replacing the full capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added option to CallbackReplacer for replacing the full capture when using Pattern with 1 group 
 
 ## [1.5.1](https://github.com/kb-dk/kb-util/tree/kb-util-1.5.1)
 ### Fixed

--- a/src/test/java/dk/kb/util/string/CallbackReplacerTest.java
+++ b/src/test/java/dk/kb/util/string/CallbackReplacerTest.java
@@ -83,7 +83,27 @@ class CallbackReplacerTest {
              // Expected
          }
     }
-    
+
+    @Test
+    void testGroupMatchFullReplace() {
+        CallbackReplacer subMatcher = new CallbackReplacer(
+                Pattern.compile("\\$\\{config:([^}]+)}"),
+                s -> "foo",
+                true);
+        assertEquals("url: \"foo\"",
+                subMatcher.apply("url: \"${config:some.path}\""));
+    }
+
+    @Test
+    void testGroupMatchGroupReplace() {
+        CallbackReplacer subMatcher = new CallbackReplacer(
+                Pattern.compile("\\$\\{config:([^}]+)}"),
+                s -> "foo",
+                false);
+        assertEquals("url: \"${config:foo}\"",
+                subMatcher.apply("url: \"${config:some.path}\""));
+    }
+
     @Test
     void streamingOutput() throws IOException {
         StringWriter out = new StringWriter();


### PR DESCRIPTION
`CallbackReplacer` supports the use of 1 capturing group in the given `Pattern`, where the replacement is for that group and not the full capture.

When used on a text such as
```
url: '${config:openapi.serverurl}'
```
with the pattern `\$\{config:([^}]+)}`, the intention would be to replace the whole capture `${config:openapi.serverurl}` and not just the group `openapi.serverurl`. To maintain backwards compatibility this should be an opt-in.

This pull request adds this functionality.