### PR TITLE
Add support for dynamic enum creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Changed how OpenApiResource handles substitution of multiple values. Now substitutinos using placeholders in yaml paths can be used in OpenAPI enums.
+
 ## [1.5.3](https://github.com/kb-dk/kb-util/tree/kb-util-1.5.3)
 ### Added
 - Added option to CallbackReplacer for replacing the full capture when using Pattern with 1 group 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- Changed how OpenApiResource handles substitution of multiple values. Now substitutinos using placeholders in yaml paths can be used in OpenAPI enums.
+- Changed how OpenApiResource handles substitution of multiple values. Now substitutinos using placeholders in yaml paths can be used in OpenAPI enums. Related to [Jira DRA-327](https://kb-dk.atlassian.net/browse/DRA-327)
 
 ## [1.5.3](https://github.com/kb-dk/kb-util/tree/kb-util-1.5.3)
 ### Added

--- a/src/main/java/dk/kb/util/webservice/OpenApiResource.java
+++ b/src/main/java/dk/kb/util/webservice/OpenApiResource.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import dk.kb.util.Resolver;
 import dk.kb.util.string.CallbackReplacer;
+import dk.kb.util.string.Strings;
+import dk.kb.util.webservice.exception.InvalidArgumentServiceException;
 import dk.kb.util.webservice.exception.NotFoundServiceException;
 import dk.kb.util.yaml.YAML;
 import org.slf4j.Logger;
@@ -23,7 +25,6 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
-import java.util.StringJoiner;
 import java.util.regex.Pattern;
 
 /**
@@ -201,23 +202,14 @@ public class OpenApiResource extends ImplBase {
         List<Object> result = config.getMultiple(yPath);
 
         if (result.isEmpty()){
-            // I am not quite sure what we should return here. Is it too harsh to throw an exception? If not, which would be correct? Illegal Argument?
             log.error("No entry has been found for yPath: '{}'.", yPath);
-            return yPath;
-        }
-        if (result.size() == 1){
-            return result.get(0).toString();
+            throw new InvalidArgumentServiceException("No entry has been found for yPath: '{}'.", yPath);
         }
 
         // If there are more than one entry, then the entries are combined to a specially formatted comma seperated string.
         // All entries are seperated by ", " to make the openAPI generator see the input ["${config:yaml.string}"] as an
         // actual array resolved as ["foo", "bar", "zoo"]
-        StringJoiner joiner = new StringJoiner("\", \"");
-        for (Object entry: result) {
-            joiner.add(entry.toString());
-        }
-
-        return joiner.toString();
+        return Strings.join(result, "\", \"");
     }
 
     /**

--- a/src/test/java/dk/kb/util/webservice/OpenApiResourceTest.java
+++ b/src/test/java/dk/kb/util/webservice/OpenApiResourceTest.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class OpenApiResourceTest {
 
@@ -20,6 +21,16 @@ public class OpenApiResourceTest {
         String yamlSpec = apiResource.getYamlSpec("util-openapi_v1")
                             .getEntity().toString();
         assertFalse(yamlSpec.contains("${config:"));
+    }
+
+    @Test
+    public void testEnumConstruction() throws IOException {
+        YAML config = YAML.resolveLayeredConfigs("conf/test.yaml");
+        OpenApiResource apiResource = new OpenApiResource();
+        OpenApiResource.setConfig(config);
+        String yamlSpec = apiResource.getYamlSpec("util-openapi_v1")
+                            .getEntity().toString();
+        assertTrue(yamlSpec.contains("enum: [\"a\", \"b\", \"c\"]"));
     }
 
 

--- a/src/test/resources/util-openapi_v1.yaml
+++ b/src/test/resources/util-openapi_v1.yaml
@@ -14,6 +14,14 @@ paths:
     get:
       summary: Returns a list of users.
       description: Optional extended description in CommonMark or HTML.
+      parameters:
+        - name: person
+          in: query
+          description: 'Example param to show enum injection'
+          required: true
+          schema:
+            type: string
+            enum: ["${config:test.arrayofstrings[*]}"]
       responses:
         '200':    # status code
           description: A JSON array of user names


### PR DESCRIPTION
This makes it possible to use enums in our dynamic config setup. 

I've tested that this works by running a local solr and datahandler. The datahandler was build with only `ds.tv` as enum value for the endpoint  `/solr/index`. Then the configuration was changed to include the enum `ds.radio` and a succesfull indexing was done locally.