### PR TITLE
Move datetime parser from doms migration repo to util repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added class DatetimeParser, which parses wrongly defined DOMS dates.
+
 
 ## [1.5.5](https://github.com/kb-dk/kb-util/tree/kb-util-1.5.5)
 ### Changed

--- a/src/main/java/dk/kb/util/DatetimeParser.java
+++ b/src/main/java/dk/kb/util/DatetimeParser.java
@@ -1,0 +1,93 @@
+package dk.kb.util;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.Locale;
+
+/**
+ * Datetime Parser used to parse wrongly formatted data from observed formats from DOMS. Examples of formats, that are
+ * fixed by this class can be seen in the test class {@code DatetimeParserTest}.
+ */
+public class DatetimeParser {
+
+
+    /**
+     * This method parses a String, datetime, to a ZonedDateTime object with pattern of String, format.
+     * Ex. parseStringToZonedDateTime("2024-02-23T08:55:00+0100", "yyyy-MM-dd'T'HH:mm:ssXXXX")
+     *
+     * @param datetime the datetime String to parse to a ZoneDatetime object
+     * @param format   the pattern of the datetime String, used to create a {@link DateTimeFormatter} object
+     * @return {@link ZonedDateTime} object
+     * @see ZonedDateTime
+     * @see DateTimeFormatter
+     */
+    public static ZonedDateTime parseStringToZonedDateTime(String datetime, String format) throws MalformedIOException {
+        try {
+            DateTimeFormatter dtf = DateTimeFormatter.ofPattern(format, Locale.ROOT);
+            return ZonedDateTime.parse(datetime, dtf);
+        } catch (DateTimeParseException e) {
+            return tryRepairZonedDateTime(datetime, format);
+        }
+    }
+
+    /**
+     * Tries to convert a time that don't fullfills the official datetimeformatter pattern
+     *
+     * @param datetime time to be converted
+     * @param format   The datetimeformatter pattern
+     * @return Returns the converted datetime. If it fails a DateTimeParseException is thrown
+     * which then will be logged in the error file
+     */
+    private static ZonedDateTime tryRepairZonedDateTime(String datetime, String format) throws MalformedIOException {
+        try {
+            // Remove spaces
+            datetime = datetime.replace(" ", "");
+            // Remove any brackets
+            datetime = datetime.replace("[", "").replace("]", "");
+            // Insert the missing "T" between date and time components
+            String formattedDateTimeString = datetime.replaceAll("(\\d{4}-\\d{2}-\\d{2})(\\d{2}:\\d{2}:\\d{2})", "$1T$2");
+            // Remove extra zeros from the time zone offset
+            String trimmedDateTimeString = formattedDateTimeString.replaceAll("(\\+|-)(\\d{2})(\\d{2})(\\d{0,2})$", "$1$2$3");
+            // Parse it.
+            DateTimeFormatter dtf = DateTimeFormatter.ofPattern(format, Locale.ROOT);
+            return ZonedDateTime.parse(trimmedDateTimeString, dtf);
+        } catch (DateTimeParseException e) {
+            return tryRepairStrangeTZ(datetime, format);
+        }
+    }
+
+    /**
+     * Tries to convert a date with wrong number of zeroes in the timezone
+     *
+     * @param datetime time to be converted
+     * @param format   The datetimeformatter pattern
+     * @return Returns the converted datetime. If it fails a DateTimeParseException is thrown
+     * which then will be logged in the error file
+     */
+    private static ZonedDateTime tryRepairStrangeTZ(String datetime, String format) throws MalformedIOException {
+        try {
+            // Find index where the charater is
+            int index = datetime.indexOf('+');
+            // Extract the content after the '+' e.g. the timezone part
+            String timeZoneOffset = datetime.substring(index + 1);
+            // remove all zeros, so only the zimezone value remains
+            String tzValue = timeZoneOffset.replace("0", "");
+            // Extract the part without timezone
+            String dateTimeWithoutTZ = datetime.substring(0, datetime.indexOf('+'));
+            // Create Timezone in correct format
+            String prefix = "+0";
+            if (tzValue.length() != 1) {
+                prefix = "+";
+            }
+            // Create the date in correct format
+            datetime = dateTimeWithoutTZ + prefix + tzValue + "00";
+            // Parse the date-time string
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern(format, Locale.ROOT);
+            return ZonedDateTime.parse(datetime, formatter);
+        } catch (RuntimeException e) {
+            throw new MalformedIOException("Could not parse/repair date: " + datetime);
+        }
+    }
+}
+

--- a/src/main/java/dk/kb/util/MalformedIOException.java
+++ b/src/main/java/dk/kb/util/MalformedIOException.java
@@ -1,0 +1,24 @@
+package dk.kb.util;
+
+import java.util.Locale;
+
+public class MalformedIOException extends Exception {
+    public MalformedIOException() {
+    }
+
+    public MalformedIOException(String message) {
+        super(message);
+    }
+
+    public MalformedIOException(String message, Object... vals) {
+        super(String.format(Locale.ROOT, message, vals));
+    }
+
+    public MalformedIOException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public MalformedIOException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/test/java/dk/kb/util/DatetimeParserTest.java
+++ b/src/test/java/dk/kb/util/DatetimeParserTest.java
@@ -1,0 +1,54 @@
+package dk.kb.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+
+public class DatetimeParserTest {
+
+    @Test
+    void testRepairZonedDateTimeOffset() throws MalformedIOException {
+        String dateTimeFormat = "yyyy-MM-dd'T'HH:mm:ss[XX][XXX]";
+
+        String date1 = "2008-02-12T06:30:00+0100"; // no ":" test
+        assertEquals(DatetimeParser.parseStringToZonedDateTime(date1,dateTimeFormat).toString(),
+                "2008-02-12T06:30+01:00");
+
+        String date2 = "2008-02-12T06:30:00+01:00"; // with ":" test
+        assertEquals(DatetimeParser.parseStringToZonedDateTime(date2,dateTimeFormat).toString(),
+                "2008-02-12T06:30+01:00");
+
+        String date3 = "[2008-02-12T06:30:00+0100]"; // Bracket test
+        assertEquals(DatetimeParser.parseStringToZonedDateTime(date3,dateTimeFormat).toString(),
+                "2008-02-12T06:30+01:00");
+
+        String date4 = " 2008-02-12T06:30 :00 +0100 "; // Space test
+        assertEquals(DatetimeParser.parseStringToZonedDateTime(date4,dateTimeFormat).toString(),
+                "2008-02-12T06:30+01:00");
+
+        String date5 = "2008-02-12T06:30:00+01000"; // 1 zero extra in timezone
+        assertEquals(DatetimeParser.parseStringToZonedDateTime(date5,dateTimeFormat).toString(),
+                "2008-02-12T06:30+01:00");
+
+        String date6 = " [2008 -02 -12 T06:30:00+01000] "; // Multi test
+        assertEquals(DatetimeParser.parseStringToZonedDateTime(date6,dateTimeFormat).toString(),
+                "2008-02-12T06:30+01:00");
+
+        String date7 = "2008-02-12T06:30:00+010"; // Wrong number og zeroes in timezone
+        assertEquals(DatetimeParser.parseStringToZonedDateTime(date7,dateTimeFormat).toString(),
+                "2008-02-12T06:30+01:00");
+
+        String date8 = "2008-02-12T06:30:00+00000100000000"; // Wrong number og zeroes in timezone Version 2
+        assertEquals(DatetimeParser.parseStringToZonedDateTime(date8,dateTimeFormat).toString(),
+                "2008-02-12T06:30+01:00");
+
+        String date9 = "2008-02-12T06:30:00+000000012000000"; // Wrong number og zeroes in timezone Version 3
+        assertEquals(DatetimeParser.parseStringToZonedDateTime(date9,dateTimeFormat).toString(),
+                "2008-02-12T06:30+12:00");
+
+        String date10 = "åååå-mm-ddTtt:mm:ss+0200"; // Garbage data
+        assertThrowsExactly(MalformedIOException.class, ()-> DatetimeParser.parseStringToZonedDateTime(date10,dateTimeFormat));
+    }
+}
+


### PR DESCRIPTION
Introducing DatetimeParser here moved from DOMS-to-preservica project. Code has already been reviewed and used there.