### PR TITLE
Fix double parameters in getCallDetails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Changed logging in ImplBase to not include mapping and endpoint, when they are identical.
 
 ## [1.5.9](https://github.com/kb-dk/kb-util/tree/kb-util-1.5.9)
 

--- a/src/main/java/dk/kb/util/webservice/ImplBase.java
+++ b/src/main/java/dk/kb/util/webservice/ImplBase.java
@@ -93,6 +93,23 @@ public abstract class ImplBase {
         return handleException(e, true, true);
     }
 
+
+    /**
+     * Exception wrapper that logs the given Exception together with information on the endpoint call.
+     * <p/>
+     * If the given exception is NOT inherited from {@link ServiceException}, it is wrapped in a {@link InternalServiceException}. If not, it will be delivered as is.
+     * In both cases the message will state the endpoint
+     * and the parameters from the client call.
+     * Also, a warning is logged, stating the endpoint and the parameters plus the given exception.
+     * <p/>
+     * This is a shortcut for {@code handleException(e, true, true)}.
+     * @param e: any kind of exception.
+     * @return a ServiceException stating endpoint and parameters.
+     */
+    protected ServiceException handleException(Exception e, boolean wrapServiceExceptions){
+        return handleException(e, true, wrapServiceExceptions);
+    }
+
     /**
      * Exception wrapper with flexible handling.
      *
@@ -142,8 +159,28 @@ public abstract class ImplBase {
             }
             accepts.append(aHeaders.nextElement());
         }
+
+
+        boolean mappingEqualsEndpoint = compareMappingWithEndpoint(mapping, endpoint);
+
+        if (mappingEqualsEndpoint){
+            if (!endpoint.startsWith("/")){
+                endpoint = "/" + endpoint;
+            }
+
+            return method + " " + context +  endpoint + (params.isEmpty() ? "" : "?" + params) +
+                    " accepts: " + accepts;
+        }
+
         return method + " " + context + "/" + mapping + endpoint + (params.isEmpty() ? "" : "?" + params) +
-               " accepts: " + accepts;
+                    " accepts: " + accepts;
+    }
+
+    private boolean compareMappingWithEndpoint(String mapping, String endpoint) {
+        String cleanMapping = mapping.replaceAll("/", "");
+        String cleanEndpoint = endpoint.replaceAll("/", "");
+
+        return cleanMapping.equals(cleanEndpoint);
     }
 
     /**

--- a/src/main/java/dk/kb/util/webservice/ImplBase.java
+++ b/src/main/java/dk/kb/util/webservice/ImplBase.java
@@ -93,23 +93,6 @@ public abstract class ImplBase {
         return handleException(e, true, true);
     }
 
-
-    /**
-     * Exception wrapper that logs the given Exception together with information on the endpoint call.
-     * <p/>
-     * If the given exception is NOT inherited from {@link ServiceException}, it is wrapped in a {@link InternalServiceException}. If not, it will be delivered as is.
-     * In both cases the message will state the endpoint
-     * and the parameters from the client call.
-     * Also, a warning is logged, stating the endpoint and the parameters plus the given exception.
-     * <p/>
-     * This is a shortcut for {@code handleException(e, true, true)}.
-     * @param e: any kind of exception.
-     * @return a ServiceException stating endpoint and parameters.
-     */
-    protected ServiceException handleException(Exception e, boolean wrapServiceExceptions){
-        return handleException(e, true, wrapServiceExceptions);
-    }
-
     /**
      * Exception wrapper with flexible handling.
      *


### PR DESCRIPTION
Implement check for mapping = endpoint. I've deployed a version of ds-discover on our devel machine using a snapshot of this. You can test the endpoint `ds-discover/v1/solr/ds/suggest?suggest.dictionary=radiotv_title_suggest&suggest.q=test&suggest.count=10&wt=json` and check that the endpoint entry is logged correctly in the log.

Afterwards I will release kb-util and bump the dependency in all ds modules.