### PR TITLE
Upgrade org json version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 /target/
 .classpath
 .project

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Marked `JSONWrapper` deprecated for removal;
+  dependency on org.json will probably be removed too
+### Updated
+- Upgraded org.json version from 20231013 to 20240303
 
 ## [1.5.13](https://github.com/kb-dk/kb-util/tree/kb-util-1.5.13)
 ### Fixed

--- a/pom.xml
+++ b/pom.xml
@@ -317,10 +317,10 @@
         <!--JSON-->
         <!-- https://mvnrepository.com/artifact/org.json/json -->
         <dependency>
-            <!--Only for the incomplete JSONWrapper-->
+            <!--Only for our incomplete JSONWrapper-->
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20231013</version>
+            <version>20240303</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -317,7 +317,7 @@
         <!--JSON-->
         <!-- https://mvnrepository.com/artifact/org.json/json -->
         <dependency>
-            <!--Only for our incomplete JSONWrapper-->
+            <!--Only for our incomplete JSONWrapper; this dependency will probably be removed in kb-util 2.0.0 -->
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>20240303</version>

--- a/src/main/java/dk/kb/util/json/JSONWrapper.java
+++ b/src/main/java/dk/kb/util/json/JSONWrapper.java
@@ -20,6 +20,7 @@ import org.json.JSONObject;
  * Not implemented.
  * Had been thought to be a wrapper for JSoup for easier access to the JSON elements.
  */
+@Deprecated(forRemoval = true)
 public class JSONWrapper {
 
     /**

--- a/src/main/java/dk/kb/util/json/JSONWrapper.java
+++ b/src/main/java/dk/kb/util/json/JSONWrapper.java
@@ -16,33 +16,26 @@ package dk.kb.util.json;
 
 import org.json.JSONObject;
 
-import java.util.Locale;
-
 /**
- * Wrapper for JSoup for easier access to the JSON elements.
+ * Not implemented.
+ * Had been thought to be a wrapper for JSoup for easier access to the JSON elements.
  */
 public class JSONWrapper {
 
     /**
-     * Resolves the Object at the given JSON path
-     * @param path the path
-     * @param json  the json
-     * @return the object
+     * Not implemented.
+     * @throws UnsupportedOperationException always
      */
     public static Object getObject(JSONObject json, String path) {
         throw new UnsupportedOperationException("Not implemented yet");
     }
-    
+
     /**
-     *  something
-      * @param path the path
-     * @return the object
+     * Not implemented.
+     * @throws UnsupportedOperationException always
      */
     public Object getObjects(String path) {
         throw new UnsupportedOperationException("Not implemented yet");
     }
-    public static void main(String[] args) {
-        JSONObject jo = new JSONObject("sss", Locale.ENGLISH);
-        throw new UnsupportedOperationException("Not implemented yet");
-    }
+
 }

--- a/src/main/java/dk/kb/util/json/JSONWrapper.java
+++ b/src/main/java/dk/kb/util/json/JSONWrapper.java
@@ -39,4 +39,7 @@ public class JSONWrapper {
         throw new UnsupportedOperationException("Not implemented yet");
     }
 
+    public static void main(String[] args) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
 }


### PR DESCRIPTION
Upgrade org.json dependency from version 20231013 to latest, that is, 20240303.
Mark JSONWrapper as deprecated for removal since it doesn’t seem to be developed into a useable state.